### PR TITLE
Split `recursive` into `recursive` and `max_depth`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Split the `--recursive` option into a `--recursive` flag and a `--max-depth` option
+- Renamed the entry point from `stac_validator` to `stac-validator`
+
 ## [v2.4.2] - 2022-03-02
 ### Changed
 
@@ -81,7 +88,7 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 - stac versions where a `stac_version` field is not present are
   no longer supported.
 
-## [1.0.0] - 2020-09-01
+## [v1.0.1] - 2020-09-01
 
 ### Added
 
@@ -106,3 +113,15 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 - Updated core validation to use validation from pystac instead of jsonchema.
 - With the newest version - 1.0.0-beta.2 - items will run through jsonchema validation before the PySTAC validation. The reason for this is that jsonschema will give more informative error messages. This should be addressed better in the future. This is not the case with the --recursive option as time can be a concern here with larger collections.
 - Logging. Various additions were made here depending on the options selected. This was done to help assist people to update their STAC collections.
+
+[Unreleased]: <https://github.com/sparkgeo/stac-validator/compare/v2.4.0..main>
+[v2.4.0]: <https://github.com/sparkgeo/stac-validator/compare/v2.3.0..v2.4.0>
+[v2.3.0]: <https://github.com/sparkgeo/stac-validator/compare/v2.2.0..v2.3.0>
+[v2.2.0]: <https://github.com/sparkgeo/stac-validator/compare/v2.1.0..v2.2.0>
+[v2.1.0]: <https://github.com/sparkgeo/stac-validator/compare/v2.0.0..v2.1.0>
+[v2.0.0]: <https://github.com/sparkgeo/stac-validator/compare/v1.0.1..v2.0.0>
+[v1.0.1]: <https://github.com/sparkgeo/stac-validator/compare/v0.5.0..v1.0.1>
+[v0.5.0]: <https://github.com/sparkgeo/stac-validator/compare/v0.1.3..v0.5.0>
+[v0.1.3]: <https://github.com/sparkgeo/stac-validator/compare/v0.1.1..v0.1.3>
+[v0.1.1]: <https://github.com/sparkgeo/stac-validator/compare/v0.1.0..v0.1.1>
+[v0.1.0]: <https://github.com/sparkgeo/stac-validator/releases/tag/v0.1.0>

--- a/README.md
+++ b/README.md
@@ -95,12 +95,12 @@ make help
 **Basic Usage**
 
 ```bash
-stac_validator --help
-
-Usage: stac_validator [OPTIONS] STAC_FILE
+stac-validator --help
+Usage: stac-validator [OPTIONS] STAC_FILE
 
 Options:
-  --lint                   Use stac-check to lint stac object.
+  --lint                   Use stac-check to lint stac object instead of
+                           validating it.
   --core                   Validate core stac object only without extensions.
   --extensions             Validate extensions only.
   --links                  Additionally validate links. Only works with
@@ -109,8 +109,9 @@ Options:
                            default mode.
   -c, --custom TEXT        Validate against a custom schema (local filepath or
                            remote schema).
-  -r, --recursive INTEGER  Recursively validate all related stac objects. A
-                           depth of -1 indicates full recursion.
+  -r, --recursive          Recursively validate all related stac objects.
+  -m, --max-depth INTEGER  Maximum depth to traverse when recursing. Ignored
+                           if `recursive == False`.
   -v, --verbose            Enables verbose output for recursive mode.
   --no_output              Do not print output to console.
   --log_file TEXT          Save full recursive output to log file (local
@@ -277,7 +278,7 @@ stac_validator https://raw.githubusercontent.com/radiantearth/stac-spec/master/e
 **--recursive**
 
 ```bash
-stac_validator https://spot-canada-ortho.s3.amazonaws.com/catalog.json --recursive 1 --verbose
+stac_validator https://spot-canada-ortho.s3.amazonaws.com/catalog.json --recursive --max-depth 1 --verbose
 [
     {
         "version": "0.8.1",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+black
 pytest
 pytest-mypy
 pre-commit

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-__version__ = "2.4.3"
+__version__ = "2.5.0"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -29,7 +29,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/stac-utils/stac-validator",
-    download_url="https://github.com/stac-utils/stac-validator/archive/v2.4.3.tar.gz",
+    download_url="https://github.com/stac-utils/stac-validator/archive/v2.5.0.tar.gz",
     install_requires=[
         "requests>=2.19.1",
         "jsonschema>=3.2.0",

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     ],
     packages=["stac_validator"],
     entry_points={
-        "console_scripts": ["stac_validator = stac_validator.stac_validator:main"]
+        "console_scripts": ["stac-validator = stac_validator.stac_validator:main"]
     },
     python_requires=">=3.7",
     tests_require=["pytest"],

--- a/stac_validator/stac_validator.py
+++ b/stac_validator/stac_validator.py
@@ -10,7 +10,11 @@ from .validate import StacValidate
 
 @click.command()
 @click.argument("stac_file")
-@click.option("--lint", is_flag=True, help="Use stac-check to lint stac object.")
+@click.option(
+    "--lint",
+    is_flag=True,
+    help="Use stac-check to lint stac object instead of validating it.",
+)
 @click.option(
     "--core", is_flag=True, help="Validate core stac object only without extensions."
 )

--- a/stac_validator/stac_validator.py
+++ b/stac_validator/stac_validator.py
@@ -13,7 +13,7 @@ from .validate import StacValidate
 @click.option(
     "--lint",
     is_flag=True,
-    help="Use stac-check to lint stac object instead of validating it.",
+    help="Use stac-check to lint the stac object in addition to validating it.",
 )
 @click.option(
     "--core", is_flag=True, help="Validate core stac object only without extensions."

--- a/stac_validator/stac_validator.py
+++ b/stac_validator/stac_validator.py
@@ -38,9 +38,14 @@ from .validate import StacValidate
 @click.option(
     "--recursive",
     "-r",
+    is_flag=True,
+    help="Recursively validate all related stac objects.",
+)
+@click.option(
+    "--max-depth",
+    "-m",
     type=int,
-    default=-2,
-    help="Recursively validate all related stac objects. A depth of -1 indicates full recursion.",
+    help="Maximum depth to traverse when recursing. Ignored if `recursive == False`.",
 )
 @click.option(
     "-v", "--verbose", is_flag=True, help="Enables verbose output for recursive mode."
@@ -56,6 +61,7 @@ def main(
     stac_file,
     lint,
     recursive,
+    max_depth,
     core,
     extensions,
     links,
@@ -73,6 +79,7 @@ def main(
         stac = StacValidate(
             stac_file=stac_file,
             recursive=recursive,
+            max_depth=max_depth,
             core=core,
             links=links,
             assets=assets,
@@ -87,7 +94,7 @@ def main(
         if no_output is False:
             click.echo(json.dumps(stac.message, indent=4))
 
-        if recursive == -2 and stac.message[0]["valid_stac"] is False:
+        if not recursive and stac.message[0]["valid_stac"] is False:
             sys.exit(1)
 
 

--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -9,7 +9,7 @@ from stac_validator import stac_validator
 
 def test_recursive_lvl_3_v070():
     stac_file = "https://radarstac.s3.amazonaws.com/stac/catalog.json"
-    stac = stac_validator.StacValidate(stac_file, recursive=4)
+    stac = stac_validator.StacValidate(stac_file, recursive=True, max_depth=4)
     stac.run()
     assert stac.message == [
         {
@@ -97,7 +97,7 @@ def test_recursive_lvl_3_v070():
 
 def test_recursive_local_v090():
     stac_file = "tests/test_data/v090/catalog.json"
-    stac = stac_validator.StacValidate(stac_file, recursive=1)
+    stac = stac_validator.StacValidate(stac_file, recursive=True, max_depth=1)
     stac.run()
     assert stac.message == [
         {
@@ -133,7 +133,7 @@ def test_recursive_local_v090():
 
 def test_recursive_v1beta1():
     stac_file = "tests/test_data/1beta1/sentinel2.json"
-    stac = stac_validator.StacValidate(stac_file, recursive=0)
+    stac = stac_validator.StacValidate(stac_file, recursive=True, max_depth=0)
     stac.run()
     assert stac.message == [
         {
@@ -149,7 +149,7 @@ def test_recursive_v1beta1():
 
 def test_recursive_v1beta2():
     stac_file = "https://raw.githubusercontent.com/stac-utils/pystac/main/tests/data-files/examples/1.0.0-beta.2/collection-spec/examples/sentinel2.json"
-    stac = stac_validator.StacValidate(stac_file, recursive=0)
+    stac = stac_validator.StacValidate(stac_file, recursive=True, max_depth=0)
     stac.run()
     assert stac.message == [
         {
@@ -167,7 +167,7 @@ def test_recursive_v1beta2():
 
 def test_recursion_collection_local_v1rc1():
     stac_file = "tests/test_data/1rc1/collection.json"
-    stac = stac_validator.StacValidate(stac_file, recursive=1)
+    stac = stac_validator.StacValidate(stac_file, recursive=True, max_depth=1)
     stac.run()
     assert stac.message == [
         {
@@ -219,7 +219,7 @@ def test_recursion_collection_local_v1rc1():
 
 def test_recursion_collection_local_v1rc2():
     stac_file = "tests/test_data/1rc2/collection.json"
-    stac = stac_validator.StacValidate(stac_file, recursive=1)
+    stac = stac_validator.StacValidate(stac_file, recursive=True, max_depth=1)
     stac.run()
     assert stac.message == [
         {
@@ -272,7 +272,7 @@ def test_recursion_collection_local_v1rc2():
 
 def test_recursion_collection_local_2_v1rc2():
     stac_file = "tests/test_data/1rc2/extensions-collection/collection.json"
-    stac = stac_validator.StacValidate(stac_file, recursive=1)
+    stac = stac_validator.StacValidate(stac_file, recursive=True, max_depth=1)
     stac.run()
     assert stac.message == [
         {

--- a/tests/test_sys_exit.py
+++ b/tests/test_sys_exit.py
@@ -4,7 +4,7 @@ import subprocess
 def test_correct_sys_exit_error_python():
     try:
         subprocess.run(
-            ["stac_validator", "tests/test_data/bad_data/bad_item_v090.json"],
+            ["stac-validator", "tests/test_data/bad_data/bad_item_v090.json"],
             check=True,
         )
         assert False
@@ -15,7 +15,7 @@ def test_correct_sys_exit_error_python():
 def test_false_sys_exit_error_python():
     try:
         subprocess.run(
-            ["stac_validator", "tests/test_data/v090/items/good_item_v090.json"],
+            ["stac-validator", "tests/test_data/v090/items/good_item_v090.json"],
             check=True,
         )
         assert True

--- a/tests/test_sys_exit.py
+++ b/tests/test_sys_exit.py
@@ -1,23 +1,18 @@
 import subprocess
 
+import pytest
+
 
 def test_correct_sys_exit_error_python():
-    try:
+    with pytest.raises(subprocess.CalledProcessError):
         subprocess.run(
             ["stac-validator", "tests/test_data/bad_data/bad_item_v090.json"],
             check=True,
         )
-        assert False
-    except subprocess.CalledProcessError:
-        assert True
 
 
 def test_false_sys_exit_error_python():
-    try:
-        subprocess.run(
-            ["stac-validator", "tests/test_data/v090/items/good_item_v090.json"],
-            check=True,
-        )
-        assert True
-    except subprocess.CalledProcessError:
-        assert False
+    subprocess.run(
+        ["stac-validator", "tests/test_data/v090/items/good_item_v090.json"],
+        check=True,
+    )


### PR DESCRIPTION
The main change of this PR is to split `recursive` into two:
- A boolean flag named `recursive`
- An int named `max_depth`

This separates the "should we recurse" decision from the "how deep should we recurse" parameter.

Additional sidecar changes (some of which are _not_ minor, so please tell me to revert them if you don't want them :-) ):
- Rename the `stac_validator` entrypoint to `stac-validator`. I was surprised, after running `pip install stac-validator`, that I didn't have a `stac-validator --help` available.
- Add black to `requirements-dev.txt`
- Some changelog and documentation updates
- Simplifying the CLI test case to use `pytest.raises`

I also had a question at https://github.com/sparkgeo/stac-validator/compare/main...gadomski:recursive-and-max-depth?expand=1#diff-901a8575e00bc5aeaa6ec79a3ee5ec98cf72e603f8d2c18556310aea8d43cfd6R251 re: the hardcoded `5` for the maximum depth that errors are reported (at least I think that's what its doing).