### PR TITLE
Exit with non-zero code when validation fails

### DIFF
--- a/stac_validator/stac_validator.py
+++ b/stac_validator/stac_validator.py
@@ -72,6 +72,7 @@ def main(
     log_file,
 ):
 
+    valid = True
     if lint is True:
         linter = Linter(stac_file, assets=True, links=True, recursive=False)
         lint_message(linter)
@@ -89,13 +90,12 @@ def main(
             no_output=no_output,
             log=log_file,
         )
-        stac.run()
+        valid = stac.run()
 
         if no_output is False:
             click.echo(json.dumps(stac.message, indent=4))
 
-        if not recursive and stac.message[0]["valid_stac"] is False:
-            sys.exit(1)
+    sys.exit(0 if valid else 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_data/v100/bad-item.json
+++ b/tests/test_data/v100/bad-item.json
@@ -1,0 +1,111 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
+  "type": "Feature",
+  "bbox": [
+    -122.59750209,
+    37.48803556,
+    -122.2880486,
+    37.613537207
+  ],
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -122.308150179,
+          37.488035566
+        ],
+        [
+          -122.597502109,
+          37.538869539
+        ],
+        [
+          -122.576687533,
+          37.613537207
+        ],
+        [
+          -122.2880486,
+          37.562818007
+        ],
+        [
+          -122.308150179,
+          37.488035566
+        ]
+      ]
+    ]
+  },
+  "properties": {
+    "title": "Full Item",
+    "description": "A STAC item without an id",
+    "datetime": null,
+    "start_datetime": "2016-05-03T13:22:30Z",
+    "end_datetime": "2016-05-03T13:27:30Z",
+    "created": "2016-05-04T00:00:01Z",
+    "updated": "2017-01-01T00:30:55Z",
+    "license": "various",
+    "providers": [
+      {
+        "name": "Remote Data, Inc",
+        "description": "Producers of awesome spatiotemporal assets",
+        "roles": [
+          "producer",
+          "processor"
+        ],
+        "url": "http://remotedata.it"
+      }
+    ],
+    "platform": "cool_sat2",
+    "instruments": [
+      "cool_sensor_v1"
+    ]
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "./catalog.json",
+      "type": "application/json",
+      "title": "Example Catalog"
+    },
+    {
+      "rel": "parent",
+      "href": "./catalog.json",
+      "type": "application/json",
+      "title": "Example Catalog"
+    },
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/CS3-20160503_132130_04.html",
+      "title": "HTML representation of this STAC Item"
+    },
+    {
+      "rel": "license",
+      "type": "text/html",
+      "href": "http://remotedata.io/license.html",
+      "title": "Data License for Remote Data, Inc."
+    }
+  ],
+  "assets": {
+    "analytic": {
+      "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/analytic.tif",
+      "title": "4-Band Analytic",
+      "eo:bands": [
+        {
+          "name": "band1"
+        },
+        {
+          "name": "band1"
+        },
+        {
+          "name": "band2"
+        },
+        {
+          "name": "band3"
+        }
+      ]
+    }
+  }
+}

--- a/tests/test_data/v100/catalog-with-bad-item.json
+++ b/tests/test_data/v100/catalog-with-bad-item.json
@@ -1,0 +1,31 @@
+{
+  "id": "examples",
+  "type": "Catalog",
+  "title": "Example Catalog",
+  "stac_version": "1.0.0",
+  "description": "This is a valid catalog with links to one valid item and one invalid item.",
+  "links": [
+    {
+      "rel": "root",
+      "href": "./catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": "./bad-item.json",
+      "type": "application/json",
+      "title": "Invalid item"
+    },
+    {
+      "rel": "item",
+      "href": "./collectionless-item.json",
+      "type": "application/json",
+      "title": "Collection with no items (standalone)"
+    },
+    {
+      "rel": "self",
+      "href": "https://raw.githubusercontent.com/radiantearth/stac-spec/v1.0.0/examples/catalog.json",
+      "type": "application/json"
+    }
+  ]
+}

--- a/tests/test_sys_exit.py
+++ b/tests/test_sys_exit.py
@@ -11,6 +11,22 @@ def test_correct_sys_exit_error_python():
         )
 
 
+def test_correct_sys_exit_error_recursion():
+    try:
+        subprocess.run(
+            [
+                "stac_validator",
+                "tests/test_data/v100/catalog-with-bad-item.json",
+                "--recursive",
+                "-1",
+            ],
+            check=True,
+        )
+        assert False
+    except subprocess.CalledProcessError:
+        assert True
+
+
 def test_false_sys_exit_error_python():
     subprocess.run(
         ["stac-validator", "tests/test_data/v090/items/good_item_v090.json"],

--- a/tests/test_sys_exit.py
+++ b/tests/test_sys_exit.py
@@ -12,19 +12,17 @@ def test_correct_sys_exit_error_python():
 
 
 def test_correct_sys_exit_error_recursion():
-    try:
+    with pytest.raises(subprocess.CalledProcessError):
         subprocess.run(
             [
-                "stac_validator",
+                "stac-validator",
                 "tests/test_data/v100/catalog-with-bad-item.json",
                 "--recursive",
-                "-1",
+                "--max-depth",
+                "10",
             ],
             check=True,
         )
-        assert False
-    except subprocess.CalledProcessError:
-        assert True
 
 
 def test_false_sys_exit_error_python():


### PR DESCRIPTION
Currently, `stac_validator` always exits with `0` if `--recursive -1` is used.  This change makes it so the script exits with `1` if validation fails (regardless of whether recursion is involved).

I haven't changed anything about the output during recursion.  Currently, messages for invalid items are not shown during recursion (see #192).  If the proposed solution there makes sense, I could add that fix in here or make another pull request.
