### PR TITLE
Cache parsed schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v2.4.3] - 2022-03-10
+### Changed
+
+ - Add schema caching
+
 ## [v2.4.2] - 2022-03-02
 ### Changed
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-__version__ = "2.4.2"
+__version__ = "2.4.3"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -28,8 +28,8 @@ setup(
     keywords="STAC validation raster",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/sparkgeo/stac-validator",
-    download_url="https://github.com/sparkgeo/stac-validator/archive/v2.3.0.tar.gz",
+    url="https://github.com/stac-utils/stac-validator",
+    download_url="https://github.com/stac-utils/stac-validator/archive/v2.4.3.tar.gz",
     install_requires=[
         "requests>=2.19.1",
         "jsonschema>=3.2.0",

--- a/stac_validator/utilities.py
+++ b/stac_validator/utilities.py
@@ -1,3 +1,4 @@
+import functools
 import json
 from urllib.parse import urlparse
 from urllib.request import urlopen
@@ -54,6 +55,11 @@ def fetch_and_parse_file(input_path) -> dict:
             data = json.load(f)
 
     return data
+
+
+@functools.lru_cache(maxsize=48)
+def fetch_and_parse_schema(input_path) -> dict:
+    return fetch_and_parse_file(input_path)
 
 
 # validate new versions at schemas.stacspec.org

--- a/stac_validator/validate.py
+++ b/stac_validator/validate.py
@@ -11,6 +11,7 @@ from requests import exceptions  # type: ignore
 
 from .utilities import (
     fetch_and_parse_file,
+    fetch_and_parse_schema,
     get_stac_type,
     link_request,
     set_schema_addr,
@@ -150,7 +151,7 @@ class StacValidate:
     def custom_validator(self):
         # in case the path to custom json schema is local
         # it may contain relative references
-        schema = fetch_and_parse_file(self.custom)
+        schema = fetch_and_parse_schema(self.custom)
         if os.path.exists(self.custom):
             custom_abspath = os.path.abspath(self.custom)
             custom_dir = os.path.dirname(custom_abspath).replace("\\", "/")
@@ -158,7 +159,7 @@ class StacValidate:
             resolver = RefResolver(custom_uri, self.custom)
             jsonschema.validate(self.stac_content, schema, resolver=resolver)
         else:
-            schema = fetch_and_parse_file(self.custom)
+            schema = fetch_and_parse_schema(self.custom)
             jsonschema.validate(self.stac_content, schema)
 
     def core_validator(self, stac_type: str):
@@ -233,7 +234,7 @@ class StacValidate:
                     self.custom = set_schema_addr(self.version, stac_type.lower())
                     message = self.create_message(stac_type, "recursive")
                     if self.version == "0.7.0":
-                        schema = fetch_and_parse_file(self.custom)
+                        schema = fetch_and_parse_schema(self.custom)
                         # this next line prevents this: unknown url type: 'geojson.json' ??
                         schema["allOf"] = [{}]
                         jsonschema.validate(self.stac_content, schema)


### PR DESCRIPTION
It looks like the schema caching added in #41 was removed in #58.  I'm not sure if this was intentional or not.  Assuming it was not intentional, this change adds schema caching back in.

~~I could change this to an LRU cache if that is preferable.~~
Update (to avoid the dependency on Python 3.9): I configured the LRU cache with the same limit it had previously.

Fixes #194.