### PR TITLE
Include detail about failing item in message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,7 +141,10 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 - Logging. Various additions were made here depending on the options selected. This was done to help assist people to update their STAC collections.
 
 [v3.0.0]: <https://github.com/sparkgeo/stac-validator/compare/v2.5.0..main>
-[v2.5.0]: <https://github.com/sparkgeo/stac-validator/compare/v2.4.0..v2.5.0>
+[v2.5.0]: <https://github.com/sparkgeo/stac-validator/compare/v2.4.3..v2.5.0>
+[v2.4.3]: <https://github.com/sparkgeo/stac-validator/compare/v2.3.0..v2.4.0>
+[v2.4.2]: <https://github.com/sparkgeo/stac-validator/compare/v2.4.1..v2.4.2>
+[v2.4.1]: <https://github.com/sparkgeo/stac-validator/compare/v2.4.0..v2.4.1>
 [v2.4.0]: <https://github.com/sparkgeo/stac-validator/compare/v2.3.0..v2.4.0>
 [v2.3.0]: <https://github.com/sparkgeo/stac-validator/compare/v2.2.0..v2.3.0>
 [v2.2.0]: <https://github.com/sparkgeo/stac-validator/compare/v2.1.0..v2.2.0>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 ### Fixed
 
 - Reordered exception handlers to avoid unreachable code
+- Details about invalid items is shown in the message when in recursive mode
 
 ## [v3.0.0] - 2022-03-11
 

--- a/stac_validator/validate.py
+++ b/stac_validator/validate.py
@@ -314,9 +314,8 @@ class StacValidate:
         except Exception as e:
             message.update(cls.create_err_msg("Exception", str(e)))
 
-        message["valid_stac"] = cls.valid
-
-        if not cls.recursive:
+        if len(message) > 0:
+            message["valid_stac"] = cls.valid
             cls.message.append(message)
 
         if cls.log != "":

--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -304,3 +304,32 @@ def test_recursion_without_max_depth():
     stac = stac_validator.StacValidate(stac_file, recursive=True)
     stac.run()
     assert len(stac.message) == 6
+
+
+def test_recursion_with_bad_item():
+    stac_file = "tests/test_data/v100/catalog-with-bad-item.json"
+    stac = stac_validator.StacValidate(stac_file, recursive=True)
+    stac.run()
+    assert len(stac.message) == 2
+    assert stac.message == [
+        {
+            "version": "1.0.0",
+            "path": "tests/test_data/v100/catalog-with-bad-item.json",
+            "schema": [
+                "https://schemas.stacspec.org/v1.0.0/catalog-spec/json-schema/catalog.json"
+            ],
+            "valid_stac": True,
+            "asset_type": "CATALOG",
+            "validation_method": "recursive",
+        },
+        {
+            "version": "1.0.0",
+            "path": "tests/test_data/v100/./bad-item.json",
+            "schema": [
+                "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json"
+            ],
+            "valid_stac": False,
+            "error_type": "ValidationError",
+            "error_message": "'id' is a required property of the root of the STAC object",
+        },
+    ]


### PR DESCRIPTION
This change makes it so detail about invalid items is shown in the message when in recursive mode.

Fixes #192.