### PR TITLE
Reorder exception handlers to avoid unreachable code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 
 - Reordered exception handlers to avoid unreachable code
 
-## [3.0.0] - 2022-03-11
+## [v3.0.0] - 2022-03-11
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased - 2022-03-14
+
+### Fixed
+
+- Reordered exception handlers to avoid unreachable code
+
 ## [3.0.0] - 2022-03-11
 
 ### Added

--- a/stac_validator/validate.py
+++ b/stac_validator/validate.py
@@ -285,12 +285,12 @@ class StacValidate:
                 cls.valid = True
                 message = cls.default_validator(stac_type)
 
-        except ValueError as e:
-            message.update(cls.create_err_msg("ValueError", str(e)))
         except URLError as e:
             message.update(cls.create_err_msg("URLError", str(e)))
         except JSONDecodeError as e:
             message.update(cls.create_err_msg("JSONDecodeError", str(e)))
+        except ValueError as e:
+            message.update(cls.create_err_msg("ValueError", str(e)))
         except TypeError as e:
             message.update(cls.create_err_msg("TypeError", str(e)))
         except FileNotFoundError as e:


### PR DESCRIPTION
Since JSONDecoderError is a subclass of ValueError, its exception handler needs to come first.