### PR TITLE
Allow missing assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased - 2022-03-14
+## Unreleased
 
 ### Added
 
@@ -15,6 +15,7 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 - Reordered exception handlers to avoid unreachable code https://github.com/stac-utils/stac-validator/pull/203/
 - Details about invalid items are shown in the message when in recursive mode https://github.com/stac-utils/stac-validator/pull/202/
 - Dockerfile - change cli command from stac_validator to stac-validator https://github.com/stac-utils/stac-validator/pull/201/
+- Items with no assets key can still be valid https://github.com/stac-utils/stac-validator/pull/206
 
 ## [v3.0.0] - 2022-03-11
 

--- a/stac_validator/validate.py
+++ b/stac_validator/validate.py
@@ -86,8 +86,10 @@ class StacValidate:
 
     def assets_validator(self) -> dict:
         initial_message = self.create_links_message()
-        for _, value in self.stac_content["assets"].items():
-            link_request(value, initial_message)
+        assets = self.stac_content.get("assets")
+        if assets:
+            for asset in assets.values():
+                link_request(asset, initial_message)
         return initial_message
 
     def links_validator(self) -> dict:

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -4,6 +4,8 @@ Description: Test --links option
 """
 __authors__ = "James Banting", "Jonathan Healy"
 
+import json
+
 from stac_validator import stac_validator
 
 
@@ -85,3 +87,10 @@ def test_assets_v100():
             },
         }
     ]
+
+
+def test_assets_on_collection_without_assets_ok():
+    stac_file = "tests/test_data/v100/collection.json"
+    stac = stac_validator.StacValidate(stac_file, assets=True)
+    is_valid = stac.run()
+    assert is_valid, json.dumps(stac.message, indent=4)


### PR DESCRIPTION
Even if the `--assets` flag is passed, STAC items should still be considered valid if they don't have an `assets` key (e.g. for Collections).

This is a backwards-compatible bug fix and can be included in a patch release.