### PR TITLE
Fix top-level `is_valid` flag for recursive jsonschema exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 - Details about invalid items are shown in the message when in recursive mode https://github.com/stac-utils/stac-validator/pull/202/
 - Dockerfile - change cli command from stac_validator to stac-validator https://github.com/stac-utils/stac-validator/pull/201/
 - Items with no assets key can still be valid https://github.com/stac-utils/stac-validator/pull/206
+- Top-level `is_valid` flag for recursive JSONSchema exceptions https://github.com/stac-utils/stac-validator/pull/208
 
 ## [v3.0.0] - 2022-03-11
 

--- a/stac_validator/validate.py
+++ b/stac_validator/validate.py
@@ -188,7 +188,7 @@ class StacValidate:
             message["assets_validated"] = self.assets_validator()
         return message
 
-    def recursive_validator(self, stac_type: str):
+    def recursive_validator(self, stac_type: str) -> bool:
         if self.skip_val is False:
             self.custom = set_schema_addr(self.version, stac_type.lower())
             message = self.create_message(stac_type, "recursive")
@@ -203,7 +203,7 @@ class StacValidate:
                     err_msg = f"{e.message} of the root of the STAC object"
                 message.update(self.create_err_msg("ValidationError", err_msg))
                 self.message.append(message)
-                return
+                return False
             message["valid_stac"] = True
             self.message.append(message)
             self.depth = self.depth + 1
@@ -255,6 +255,7 @@ class StacValidate:
                         self.message.append(message)
                     if self.verbose is True:
                         click.echo(json.dumps(message, indent=4))
+        return True
 
     def validate_dict(cls, stac_content):
         cls.stac_content = stac_content
@@ -279,8 +280,7 @@ class StacValidate:
                 cls.custom_validator()
                 cls.valid = True
             elif cls.recursive:
-                cls.recursive_validator(stac_type)
-                cls.valid = True
+                cls.valid = cls.recursive_validator(stac_type)
             elif cls.extensions is True:
                 message = cls.extensions_validator(stac_type)
             else:

--- a/tests/test_data/v100/item-without-collection-link.json
+++ b/tests/test_data/v100/item-without-collection-link.json
@@ -1,0 +1,58 @@
+{
+    "stac_version": "1.0.0",
+    "stac_extensions": [],
+    "type": "Feature",
+    "id": "item-without-collection-link",
+    "bbox": [
+        172.91173669923782,
+        1.3438851951615003,
+        172.95469614953714,
+        1.3690476620161975
+    ],
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    172.91173669923782,
+                    1.3438851951615003
+                ],
+                [
+                    172.95469614953714,
+                    1.3438851951615003
+                ],
+                [
+                    172.95469614953714,
+                    1.3690476620161975
+                ],
+                [
+                    172.91173669923782,
+                    1.3690476620161975
+                ],
+                [
+                    172.91173669923782,
+                    1.3438851951615003
+                ]
+            ]
+        ]
+    },
+    "properties": {
+        "datetime": "2020-12-11T22:38:32.125000Z"
+    },
+    "collection": "simple-collection",
+    "links": [
+        {
+            "rel": "root",
+            "href": "./collection.json",
+            "type": "application/json",
+            "title": "Simple Example Collection"
+        },
+        {
+            "rel": "parent",
+            "href": "./collection.json",
+            "type": "application/json",
+            "title": "Simple Example Collection"
+        }
+    ],
+    "assets": {}
+}

--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -333,3 +333,25 @@ def test_recursion_with_bad_item():
             "error_message": "'id' is a required property of the root of the STAC object",
         },
     ]
+
+
+def test_recursion_with_missing_collection_link():
+    stac_file = "tests/test_data/v100/item-without-collection-link.json"
+    stac = stac_validator.StacValidate(stac_file, recursive=True)
+    assert not stac.run()
+    assert not stac.valid
+    assert len(stac.message) == 1
+    assert stac.message == [
+        {
+            "asset_type": "ITEM",
+            "version": "1.0.0",
+            "path": "tests/test_data/v100/item-without-collection-link.json",
+            "schema": [
+                "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json"
+            ],
+            "valid_stac": False,
+            "validation_method": "recursive",
+            "error_type": "ValidationError",
+            "error_message": "'simple-collection' should not be valid under {}. Error is in collection",
+        },
+    ]


### PR DESCRIPTION
The recursive validator catches jsonschema exceptions and sets the appropriate message. However, because it catches and doesn't re-raise the exception, the higher-level `run` method was still setting `is_valid` to `True`. This PR fixes the problem by returning `False` from the recursive validator if a jsonschema exception was caught, and True otherwise. Includes a unit test demonstrating the issue.

## Related issues

- Blocking https://github.com/stac-utils/stactools/issues/255