### PR TITLE
Make Validation errors clearer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 
 ## Unreleased
 
+### Changed
+
+- Changed 'ValidationError' error type to 'JSONSchemaValidationError'
+
 ## [v3.1.0] - 2022-04-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 
 ### Changed
 
-- Changed 'ValidationError' error type to 'JSONSchemaValidationError'
+- Changed 'ValidationError' error type to 'JSONSchemaValidationError' https://github.com/stac-utils/stac-validator/pull/213
 
 ## [v3.1.0] - 2022-04-28
 

--- a/stac_validator/validate.py
+++ b/stac_validator/validate.py
@@ -140,7 +140,7 @@ class StacValidate:
                     err_msg = f"{e.message}. Error is in {' -> '.join([str(i) for i in e.absolute_path])}"
                 else:
                     err_msg = f"{e.message} of the root of the STAC object"
-                message = self.create_err_msg("ValidationError", err_msg)
+                message = self.create_err_msg("JSONSchemaValidationError", err_msg)
                 return message
             except Exception as e:
                 valid = False
@@ -201,7 +201,9 @@ class StacValidate:
                     err_msg = f"{e.message}. Error is in {' -> '.join([str(i) for i in e.absolute_path])}"
                 else:
                     err_msg = f"{e.message} of the root of the STAC object"
-                message.update(self.create_err_msg("ValidationError", err_msg))
+                message.update(
+                    self.create_err_msg("JSONSchemaValidationError", err_msg)
+                )
                 self.message.append(message)
                 return False
             message["valid_stac"] = True
@@ -305,10 +307,10 @@ class StacValidate:
             message.update(cls.create_err_msg("OSError", str(e)))
         except jsonschema.exceptions.ValidationError as e:
             if e.absolute_path:
-                err_msg = f"JSONSchemaError {e.message}. Error is in {' -> '.join([str(i) for i in e.absolute_path])} "
+                err_msg = f"{e.message}. Error is in {' -> '.join([str(i) for i in e.absolute_path])} "
             else:
-                err_msg = f"JSONSchemaError {e.message} of the root of the STAC object"
-            message.update(cls.create_err_msg("ValidationError", err_msg))
+                err_msg = f"{e.message} of the root of the STAC object"
+            message.update(cls.create_err_msg("JSONSchemaValidationError", err_msg))
         except KeyError as e:
             message.update(cls.create_err_msg("KeyError", str(e)))
         except HTTPError as e:

--- a/stac_validator/validate.py
+++ b/stac_validator/validate.py
@@ -305,9 +305,9 @@ class StacValidate:
             message.update(cls.create_err_msg("OSError", str(e)))
         except jsonschema.exceptions.ValidationError as e:
             if e.absolute_path:
-                err_msg = f"{e.message}. Error is in {' -> '.join([str(i) for i in e.absolute_path])}"
+                err_msg = f"JSONSchemaError {e.message}. Error is in {' -> '.join([str(i) for i in e.absolute_path])} "
             else:
-                err_msg = f"{e.message} of the root of the STAC object"
+                err_msg = f"JSONSchemaError {e.message} of the root of the STAC object"
             message.update(cls.create_err_msg("ValidationError", err_msg))
         except KeyError as e:
             message.update(cls.create_err_msg("KeyError", str(e)))

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -22,7 +22,7 @@ def test_assets_v090():
                 "https://cdn.staclint.com/v0.9.0/item.json",
             ],
             "valid_stac": False,
-            "error_type": "ValidationError",
+            "error_type": "JSONSchemaValidationError",
             "error_message": "-0.00751271 is less than the minimum of 0. Error is in properties -> view:off_nadir",
             "validation_method": "default",
             "assets_validated": {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -83,7 +83,7 @@ def test_core_bad_item_local_v090():
             "validation_method": "core",
             "schema": ["https://cdn.staclint.com/v0.9.0/item.json"],
             "valid_stac": False,
-            "error_type": "ValidationError",
+            "error_type": "JSONSchemaValidationError",
             "error_message": "'id' is a required property of the root of the STAC object",
         }
     ]

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -20,7 +20,7 @@ def test_custom_item_remote_schema_v080():
             "asset_type": "ITEM",
             "validation_method": "custom",
             "valid_stac": False,
-            "error_type": "ValidationError",
+            "error_type": "JSONSchemaValidationError",
             "error_message": "'bbox' is a required property of the root of the STAC object",
         }
     ]
@@ -74,7 +74,7 @@ def test_custom_bad_item_remote_schema_v090():
             "validation_method": "custom",
             "schema": ["https://cdn.staclint.com/v0.9.0/item.json"],
             "valid_stac": False,
-            "error_type": "ValidationError",
+            "error_type": "JSONSchemaValidationError",
             "error_message": "'id' is a required property of the root of the STAC object",
         }
     ]
@@ -115,7 +115,7 @@ def test_custom_eo_error_v1rc2():
             "asset_type": "ITEM",
             "validation_method": "custom",
             "valid_stac": False,
-            "error_type": "ValidationError",
-            "error_message": "'panchromatic' is not one of ['coastal', 'blue', 'green', 'red', 'rededge', 'yellow', 'pan', 'nir', 'nir08', 'nir09', 'cirrus', 'swir16', 'swir22', 'lwir', 'lwir11', 'lwir12']. Error is in assets -> B8 -> eo:bands -> 0 -> common_name",
+            "error_type": "JSONSchemaValidationError",
+            "error_message": "'panchromatic' is not one of ['coastal', 'blue', 'green', 'red', 'rededge', 'yellow', 'pan', 'nir', 'nir08', 'nir09', 'cirrus', 'swir16', 'swir22', 'lwir', 'lwir11', 'lwir12']. Error is in assets -> B8 -> eo:bands -> 0 -> common_name ",
         }
     ]

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -151,7 +151,7 @@ def test_local_v1rc2():
             "path": "tests/test_data/1rc2/extensions-collection/./proj-example/proj-example.json",
             "schema": ["https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
             "valid_stac": False,
-            "error_type": "ValidationError",
+            "error_type": "JSONSchemaValidationError",
             "error_message": "'panchromatic' is not one of ['coastal', 'blue', 'green', 'red', 'rededge', 'yellow', 'pan', 'nir', 'nir08', 'nir09', 'cirrus', 'swir16', 'swir22', 'lwir', 'lwir11', 'lwir12']. Error is in assets -> B8 -> eo:bands -> 0 -> common_name",
         }
     ]

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -20,7 +20,7 @@ def test_poorly_formatted_v090():
                 "https://cdn.staclint.com/v0.9.0/item.json",
             ],
             "valid_stac": False,
-            "error_type": "ValidationError",
+            "error_type": "JSONSchemaValidationError",
             "error_message": "-0.00751271 is less than the minimum of 0. Error is in properties -> view:off_nadir",
             "validation_method": "default",
             "links_validated": {

--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -329,7 +329,7 @@ def test_recursion_with_bad_item():
                 "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json"
             ],
             "valid_stac": False,
-            "error_type": "ValidationError",
+            "error_type": "JSONSchemaValidationError",
             "error_message": "'id' is a required property of the root of the STAC object",
         },
     ]
@@ -351,7 +351,7 @@ def test_recursion_with_missing_collection_link():
             ],
             "valid_stac": False,
             "validation_method": "recursive",
-            "error_type": "ValidationError",
+            "error_type": "JSONSchemaValidationError",
             "error_message": "'simple-collection' should not be valid under {}. Error is in collection",
         },
     ]


### PR DESCRIPTION
Using str(e) as suggested here https://github.com/stac-utils/stac-validator/issues/212 created some error messages that were 20 to 30 lines long. I don't think this is acceptable. I didn't write the original code but I think it was written the way it was to manage long error messages. JSONSchema wants to re-print the entire stac object sometimes with their str method.

I have changed the 'ValidationError' error type to "JSONSchemaValidationError'. A User should now know to check the schema to find their error if the resulting message isn't clear enough. 