### PR TITLE
Move verbose messaging for --recursive

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.11]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     
     steps:
 

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
     
     steps:
 

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10.1, 3.11]
+        python-version: [3.7, 3.8, 3.9, 3.11]
     
     steps:
 

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: [3.7, 3.8, 3.9, 3.10.1, 3.11]
     
     steps:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v3.3.1] - 2022-12-16
+
+### Fixed
+
+- Moved --verbose messaging for --recursive https://github.com/stac-utils/stac-validator/pull/222
+
 ## [v3.3.0] - 2022-11-28
 
 ### Added
@@ -171,7 +177,8 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 - With the newest version - 1.0.0-beta.2 - items will run through jsonchema validation before the PySTAC validation. The reason for this is that jsonschema will give more informative error messages. This should be addressed better in the future. This is not the case with the --recursive option as time can be a concern here with larger collections.
 - Logging. Various additions were made here depending on the options selected. This was done to help assist people to update their STAC collections.
 
-[Unreleased]: <https://github.com/sparkgeo/stac-validator/compare/v3.3.0..main>
+[Unreleased]: <https://github.com/sparkgeo/stac-validator/compare/v3.3.1..main>
+[v3.3.1]: <https://github.com/sparkgeo/stac-validator/compare/v3.3.0..v3.3.1>
 [v3.3.0]: <https://github.com/sparkgeo/stac-validator/compare/v3.2.0..v3.3.0>
 [v3.2.0]: <https://github.com/sparkgeo/stac-validator/compare/v3.1.0..v3.2.0>
 [v3.1.0]: <https://github.com/sparkgeo/stac-validator/compare/v3.0.0..v3.1.0>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 
 ### Fixed
 
-- Moved --verbose messaging for --recursive https://github.com/stac-utils/stac-validator/pull/222
+- Moved --verbose messaging for --recursive as --verbose was printing out the wrong messages https://github.com/stac-utils/stac-validator/pull/222
 
 ## [v3.3.0] - 2022-11-28
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-__version__ = "3.3.0"
+__version__ = "3.3.1"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/stac_validator/validate.py
+++ b/stac_validator/validate.py
@@ -217,9 +217,14 @@ class StacValidate:
                     self.create_err_msg("JSONSchemaValidationError", err_msg)
                 )
                 self.message.append(message)
+                if self.verbose is True:
+                    click.echo(json.dumps(message, indent=4))
                 return False
+
             message["valid_stac"] = True
             self.message.append(message)
+            if self.verbose is True:
+                click.echo(json.dumps(message, indent=4))
             self.depth = self.depth + 1
             if self.max_depth:
                 if self.depth >= self.max_depth:
@@ -243,9 +248,6 @@ class StacValidate:
                     stac_type = get_stac_type(self.stac_content).lower()
 
                 if link["rel"] == "child":
-
-                    if self.verbose is True:
-                        click.echo(json.dumps(message, indent=4))
                     self.recursive_validator(stac_type)
 
                 if link["rel"] == "item":
@@ -267,8 +269,6 @@ class StacValidate:
                         not self.max_depth or self.max_depth < 5
                     ):  # TODO this should be configurable, correct?
                         self.message.append(message)
-                    if self.verbose is True:
-                        click.echo(json.dumps(message, indent=4))
         return True
 
     def validate_dict(self, stac_content):

--- a/tox/Dockerfile-tox
+++ b/tox/Dockerfile-tox
@@ -4,5 +4,5 @@ COPY . /code/
 RUN export LC_ALL=C.UTF-8 && \
     export LANG=C.UTF-8 && \
     pip3 install . && \
-    pip3 install tox==3.23.0 && \
+    pip3 install tox==4.0.11 && \
     tox


### PR DESCRIPTION
https://github.com/stac-utils/stac-check/issues/97

Verbose messaging in --recursive was printing the wrong messages, making it look like the same stac objects were being validated multiple times. 