### PR TITLE
Fix stac-pydantic setup, v3.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 
 ## [Unreleased]
 
+## [v3.8.1] - 2025-06-04
+
+### Fixed
+- Fixed the pydantic extra dependency in setup.py to properly install stac-pydantic when using `pip install stac-validator[pydantic]` [#254](https://github.com/stac-utils/stac-validator/pull/254)
+
 ## [v3.8.0] - 2025-06-03
 
 ### Added
@@ -251,7 +256,8 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 - With the newest version - 1.0.0-beta.2 - items will run through jsonchema validation before the PySTAC validation. The reason for this is that jsonschema will give more informative error messages. This should be addressed better in the future. This is not the case with the --recursive option as time can be a concern here with larger collections.
 - Logging. Various additions were made here depending on the options selected. This was done to help assist people to update their STAC collections.
 
-[Unreleased]: https://github.com/sparkgeo/stac-validator/compare/v3.8.0..main
+[Unreleased]: https://github.com/sparkgeo/stac-validator/compare/v3.8.1..main
+[v3.8.1]: https://github.com/sparkgeo/stac-validator/compare/v3.8.0..v3.8.1
 [v3.8.0]: https://github.com/sparkgeo/stac-validator/compare/v3.7.0..v3.8.0
 [v3.7.0]: https://github.com/sparkgeo/stac-validator/compare/v3.6.0..v3.7.0
 [v3.6.0]: https://github.com/sparkgeo/stac-validator/compare/v3.5.0..v3.6.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-__version__ = "3.8.0"
+__version__ = "3.8.1"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -29,7 +29,6 @@ setup(
         "requests>=2.32.3",
         "jsonschema>=4.23.0",
         "click>=8.1.8",
-        "stac-pydantic>=3.3.0",
         "referencing>=0.35.1",
         "pyYAML>=6.0.1",
     ],
@@ -38,6 +37,9 @@ setup(
             "pytest",
             "requests-mock",
             "types-setuptools",
+        ],
+        "pydantic": [
+            "stac-pydantic>=3.3.0",
         ],
     },
     packages=["stac_validator"],


### PR DESCRIPTION
- Fixed the pydantic extra dependency in setup.py to properly install stac-pydantic when using `pip install stac-validator[pydantic]`