### PR TITLE
Create universal verbose mode for better error messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 ## [Unreleased]
 
 ### Added
-- Added separate `recommendation` field in error messages when running in non-verbose mode
-- Verbose error messages for JSONSchemaValidationErrors
+- Added separate `recommendation` field in error messages when running in non-verbose mode [#257](https://github.com/stac-utils/stac-validator/pull/257)
+- Verbose error messages for JSONSchemaValidationErrors [#257](https://github.com/stac-utils/stac-validator/pull/257)
 
 ### Changed
-- Changed --verbose for recursive mode to --trace-recursive to make way for more comprehensive error messaging
+- Changed --verbose for recursive mode to --trace-recursive to make way for more comprehensive error messaging [#257](https://github.com/stac-utils/stac-validator/pull/257)
 
 ## [v3.8.1] - 2025-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 
 ## [Unreleased]
 
+### Added
+- Added separate `recommendation` field in error messages when running in non-verbose mode
+- Verbose error messages for JSONSchemaValidationErrors
+
+### Changed
+- Changed --verbose for recursive mode to --trace-recursive to make way for more comprehensive error messaging
+
 ## [v3.8.1] - 2025-06-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -172,13 +172,15 @@ Options:
                                   be used multiple times.
   -p, --pages INTEGER             Maximum number of pages to validate via
                                   --item-collection. Defaults to one page.
-  -v, --verbose                   Enables verbose output for recursive mode.
+  -t, --trace-recursion           Enables verbose output for recursive mode.
   --no_output                     Do not print output to console.
   --log_file TEXT                 Save full recursive output to log file
                                   (local filepath).
   --pydantic                      Validate using stac-pydantic models for enhanced
                                   type checking and validation.
   --schema-config TEXT            Path to a YAML or JSON schema config file.
+  --verbose                       Enable verbose output. This will output
+                                  additional information during validation.
   --help                          Show this message and exit.
 ```
 
@@ -370,7 +372,7 @@ $ stac-validator https://raw.githubusercontent.com/radiantearth/stac-spec/master
 ### --recursive
 
 ```bash
-$ stac-validator https://spot-canada-ortho.s3.amazonaws.com/catalog.json --recursive --max-depth 1 --verbose
+$ stac-validator https://spot-canada-ortho.s3.amazonaws.com/catalog.json --recursive --max-depth 1 --trace-recursion
 ```
 
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,7 @@ setup(
         "pyYAML>=6.0.1",
     ],
     extras_require={
-        "dev": [
-            "pytest",
-            "requests-mock",
-            "types-setuptools",
-        ],
+        "dev": ["pytest", "requests-mock", "types-setuptools", "stac-pydantic>=3.3.0"],
         "pydantic": [
             "stac-pydantic>=3.3.0",
         ],

--- a/stac_validator/stac_validator.py
+++ b/stac_validator/stac_validator.py
@@ -159,7 +159,7 @@ def collections_summary(message: List[Dict[str, Any]]) -> None:
 @click.option(
     "--verbose",
     is_flag=True,
-    help="Enable verbose output. This will output additional information during validation."
+    help="Enable verbose output. This will output additional information during validation.",
 )
 def main(
     stac_file: str,

--- a/stac_validator/stac_validator.py
+++ b/stac_validator/stac_validator.py
@@ -140,7 +140,10 @@ def collections_summary(message: List[Dict[str, Any]]) -> None:
     help="Maximum number of pages to validate via --item-collection. Defaults to one page.",
 )
 @click.option(
-    "-v", "--verbose", is_flag=True, help="Enables verbose output for recursive mode."
+    "-t",
+    "--trace-recursion",
+    is_flag=True,
+    help="Enables verbose output for recursive mode.",
 )
 @click.option("--no_output", is_flag=True, help="Do not print output to console.")
 @click.option(
@@ -169,7 +172,7 @@ def main(
     custom: str,
     schema_config: str,
     schema_map: List[Tuple],
-    verbose: bool,
+    trace_recursion: bool,
     no_output: bool,
     log_file: str,
     pydantic: bool,
@@ -193,7 +196,7 @@ def main(
         custom (str): Path to a custom schema file to validate against.
         schema_config (str): Path to a custom schema config file to validate against.
         schema_map (list(tuple)): List of tuples each having two elememts. First element is the schema path to be replaced by the path in the second element.
-        verbose (bool): Whether to enable verbose output for recursive mode.
+        trace_recursion (bool): Whether to enable verbose output for recursive mode.
         no_output (bool): Whether to print output to console.
         log_file (str): Path to a log file to save full recursive output.
         pydantic (bool): Whether to validate using stac-pydantic models for enhanced type checking and validation.
@@ -226,7 +229,7 @@ def main(
         custom=custom,
         schema_config=schema_config,
         schema_map=schema_map_dict,
-        verbose=verbose,
+        trace_recursion=trace_recursion,
         log=log_file,
         pydantic=pydantic,
     )

--- a/stac_validator/stac_validator.py
+++ b/stac_validator/stac_validator.py
@@ -156,6 +156,11 @@ def collections_summary(message: List[Dict[str, Any]]) -> None:
     is_flag=True,
     help="Validate using stac-pydantic models for enhanced type checking and validation.",
 )
+@click.option(
+    "--verbose",
+    is_flag=True,
+    help="Enable verbose output. This will output additional information during validation."
+)
 def main(
     stac_file: str,
     collections: bool,
@@ -176,6 +181,7 @@ def main(
     no_output: bool,
     log_file: str,
     pydantic: bool,
+    verbose: bool = False,
 ) -> None:
     """Main function for the `stac-validator` command line tool. Validates a STAC file
     against the STAC specification and prints the validation results to the console as JSON.
@@ -200,6 +206,7 @@ def main(
         no_output (bool): Whether to print output to console.
         log_file (str): Path to a log file to save full recursive output.
         pydantic (bool): Whether to validate using stac-pydantic models for enhanced type checking and validation.
+        verbose (bool): Whether to enable verbose output. This will output additional information during validation.
 
     Returns:
         None
@@ -232,6 +239,7 @@ def main(
         trace_recursion=trace_recursion,
         log=log_file,
         pydantic=pydantic,
+        verbose=verbose,
     )
     if not item_collection and not collections:
         valid = stac.run()

--- a/stac_validator/utilities.py
+++ b/stac_validator/utilities.py
@@ -295,10 +295,21 @@ def load_schema_config(config_path: str) -> dict:
 
 
 def extract_relevant_oneof_error(error, instance=None):
-    """
-    Given a jsonschema.ValidationError for a 'oneOf' failure,
-    return the most relevant sub-error, preferably the one matching the instance's 'type'.
-    If not found, return the first sub-error.
+    """Extract the most relevant error from a 'oneOf' validation error.
+
+    Given a jsonschema.ValidationError for a 'oneOf' failure, this function returns
+    the most relevant sub-error, with preference given to errors matching the instance's 'type'.
+    If no matching type is found, it falls back to returning the first sub-error.
+
+    Args:
+        error (jsonschema.ValidationError): The validation error from a 'oneOf' validation.
+        instance (dict, optional): The instance being validated. If provided and contains a 'type'
+            field, the function will try to find a matching schema for that type. Defaults to None.
+
+    Returns:
+        jsonschema.ValidationError: The most relevant sub-error from the 'oneOf' validation.
+            If the error is not a 'oneOf' validation error or has no context, returns the
+            original error unchanged.
     """
     if error.validator == "oneOf" and hasattr(error, "context") and error.context:
         if instance and "type" in instance:

--- a/stac_validator/utilities.py
+++ b/stac_validator/utilities.py
@@ -9,9 +9,9 @@ from urllib.request import Request, urlopen
 import requests  # type: ignore
 import yaml  # type: ignore
 from jsonschema import Draft202012Validator
-from referencing import Registry, Resource
-from referencing.jsonschema import DRAFT202012
-from referencing.typing import URI
+from referencing import Registry, Resource  # type: ignore
+from referencing.jsonschema import DRAFT202012  # type: ignore
+from referencing.typing import URI  # type: ignore
 
 NEW_VERSIONS = [
     "1.0.0-beta.2",

--- a/stac_validator/validate.py
+++ b/stac_validator/validate.py
@@ -10,6 +10,7 @@ from jsonschema.exceptions import best_match
 from requests import exceptions  # type: ignore
 
 from .utilities import (
+    extract_relevant_oneof_error,
     fetch_and_parse_file,
     fetch_and_parse_schema,
     get_stac_type,
@@ -232,6 +233,9 @@ class StacValidate:
             dict: Dictionary containing error information.
         """
         self.valid = False
+        if not self.verbose:
+            err_msg += " For more accurate error information, rerun with --verbose."
+
         message = {
             "version": self.version,
             "path": self.stac_file,
@@ -408,6 +412,7 @@ class StacValidate:
 
         except jsonschema.exceptions.ValidationError as e:
             verbose_error = e
+            e = extract_relevant_oneof_error(e, self.stac_content)
             if self.recursive:
                 raise
             if e.context:

--- a/stac_validator/validate.py
+++ b/stac_validator/validate.py
@@ -243,7 +243,7 @@ class StacValidate:
 
     def create_err_msg(
         self, err_type: str, err_msg: str, error_obj: Optional[Exception] = None
-    ) -> Dict:
+    ) -> Dict[str, Union[str, bool, List[str], Dict[str, Any]]]:
         """
         Create a standardized error message dictionary and mark validation as failed.
 
@@ -257,14 +257,25 @@ class StacValidate:
         """
         self.valid = False
 
-        message = {
-            "version": self.version,
-            "path": self.stac_file,
-            "schema": [self.schema],
+        # Ensure all values are of the correct type
+        version_str: str = str(self.version) if self.version is not None else ""
+        path_str: str = str(self.stac_file) if self.stac_file is not None else ""
+
+        # Ensure schema is properly typed
+        schema_value: str = ""
+        if self.schema is not None:
+            schema_value = str(self.schema)
+        schema_field: List[str] = [schema_value] if schema_value else []
+
+        message: Dict[str, Union[str, bool, List[str], Dict[str, Any]]] = {
+            "version": version_str,
+            "path": path_str,
+            "schema": schema_field,  # Ensure schema is a list of strings or None
             "valid_stac": False,
             "error_type": err_type,
             "error_message": err_msg,
         }
+
         if self.verbose and error_obj is not None:
             verbose_err = self._create_verbose_err_msg(error_obj)
             if isinstance(verbose_err, dict):
@@ -275,6 +286,7 @@ class StacValidate:
             message["recommendation"] = (
                 "For more accurate error information, rerun with --verbose."
             )
+
         return message
 
     def create_links_message(self) -> Dict:

--- a/stac_validator/validate.py
+++ b/stac_validator/validate.py
@@ -192,8 +192,13 @@ class StacValidate:
         # else:
         #     verbose_details["instance_snippet"] = None
 
-        if error.schema is not None and error.validator is not None:
-            verbose_details["schema"] = error.schema[error.validator]
+        if (
+            error.schema is not None
+            and error.validator is not None
+            and isinstance(error.schema, dict)
+            and isinstance(error.validator, str)
+        ):
+            verbose_details["schema"] = error.schema.get(error.validator)
         else:
             verbose_details["schema"] = None
 
@@ -261,7 +266,11 @@ class StacValidate:
             "error_message": err_msg,
         }
         if self.verbose and error_obj is not None:
-            message["error_verbose"] = self._create_verbose_err_msg(error_obj)
+            verbose_err = self._create_verbose_err_msg(error_obj)
+            if isinstance(verbose_err, dict):
+                message["error_verbose"] = verbose_err
+            else:
+                message["error_verbose"] = {"detail": str(verbose_err)}
         else:
             message["recommendation"] = (
                 "For more accurate error information, rerun with --verbose."

--- a/stac_validator/validate.py
+++ b/stac_validator/validate.py
@@ -44,7 +44,8 @@ class StacValidate:
         pydantic (bool): Whether to validate using Pydantic models.
         schema_config (str): The local filepath or remote URL of a custom JSON schema config to validate the STAC object.
         schema_map (Optional[Dict[str, str]]): A dictionary mapping schema paths to their replacements.
-
+        verbose (bool): Whether to enable verbose output.
+        
     Methods:
         run(): Validates the STAC object and returns whether it is valid.
         validate_item_collection(): Validates an item collection.
@@ -70,6 +71,7 @@ class StacValidate:
         trace_recursion: bool = False,
         log: str = "",
         pydantic: bool = False,
+        verbose: bool = False,
     ):
         self.stac_file = stac_file
         self.collections = collections
@@ -95,6 +97,7 @@ class StacValidate:
         self.valid = False
         self.log = log
         self.pydantic = pydantic
+        self.verbose = verbose
 
         self._original_schema_paths = {}
         cli_schema_map = schema_map or {}

--- a/stac_validator/validate.py
+++ b/stac_validator/validate.py
@@ -39,7 +39,7 @@ class StacValidate:
         headers (dict): HTTP headers to include in the requests.
         extensions (bool): Whether to only validate STAC object extensions.
         custom (str): The local filepath or remote URL of a custom JSON schema to validate the STAC object.
-        verbose (bool): Whether to enable verbose output in recursive mode.
+        trace_recursion (bool): Whether to enable verbose output in recursive mode.
         log (str): The local filepath to save the output of the recursive validation to.
         pydantic (bool): Whether to validate using Pydantic models.
         schema_config (str): The local filepath or remote URL of a custom JSON schema config to validate the STAC object.
@@ -67,7 +67,7 @@ class StacValidate:
         custom: str = "",
         schema_config: Optional[str] = None,
         schema_map: Optional[Dict[str, str]] = None,
-        verbose: bool = False,
+        trace_recursion: bool = False,
         log: str = "",
         pydantic: bool = False,
     ):
@@ -91,7 +91,7 @@ class StacValidate:
         self.version = ""
         self.depth: int = 0
         self.skip_val = False
-        self.verbose = verbose
+        self.trace_recursion = trace_recursion
         self.valid = False
         self.log = log
         self.pydantic = pydantic
@@ -430,14 +430,14 @@ class StacValidate:
                     self.create_err_msg("JSONSchemaValidationError", err_msg)
                 )
                 self.message.append(message)
-                if self.verbose:
+                if self.trace_recursion:
                     click.echo(json.dumps(message, indent=4))
                 return valid
 
             valid = True
             message["valid_stac"] = valid
             self.message.append(message)
-            if self.verbose:
+            if self.trace_recursion:
                 click.echo(json.dumps(message, indent=4))
 
             self.depth += 1
@@ -742,8 +742,8 @@ class StacValidate:
             with open(self.log, "w") as f:
                 f.write(json.dumps(self.message, indent=4))
 
-        # filter message to only show errors if valid is False unless verbose mode is on
-        if self.recursive and not self.valid and not self.verbose:
+        # filter message to only show errors if valid is False unless trace_recursion mode is on
+        if self.recursive and not self.valid and not self.trace_recursion:
             filtered_messages = []
             for message in self.message:
                 if not message["valid_stac"]:

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -22,7 +22,8 @@ def test_assets_v090():
             ],
             "valid_stac": False,
             "error_type": "JSONSchemaValidationError",
-            "error_message": "-0.00751271 is less than the minimum of 0. Error is in properties -> view:off_nadir",
+            "error_message": "-0.00751271 is less than the minimum of 0. Error is in properties -> view:off_nadir ",
+            "recommendation": "For more accurate error information, rerun with --verbose.",
             "validation_method": "default",
             "assets_validated": {
                 "format_valid": [

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -84,6 +84,7 @@ def test_core_bad_item_local_v090():
             "valid_stac": False,
             "error_type": "JSONSchemaValidationError",
             "error_message": "'id' is a required property",
+            "recommendation": "For more accurate error information, rerun with --verbose.",
         }
     ]
 

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -21,6 +21,7 @@ def test_custom_item_remote_schema_v080():
             "valid_stac": False,
             "error_type": "JSONSchemaValidationError",
             "error_message": "'bbox' is a required property",
+            "recommendation": "For more accurate error information, rerun with --verbose.",
         }
     ]
 
@@ -75,6 +76,7 @@ def test_custom_bad_item_remote_schema_v090():
             "valid_stac": False,
             "error_type": "JSONSchemaValidationError",
             "error_message": "'id' is a required property",
+            "recommendation": "For more accurate error information, rerun with --verbose.",
         }
     ]
 

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -42,7 +42,7 @@ def test_header():
             {
                 "version": "",
                 "path": "https://localhost/tests/test_data/v110/simple-item.json",
-                "schema": [""],
+                "schema": [],
                 "valid_stac": False,
                 "error_type": "HTTPError",
                 "error_message": "403 Client Error: None for url: https://localhost/tests/test_data/v110/simple-item.json",

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -46,5 +46,6 @@ def test_header():
                 "valid_stac": False,
                 "error_type": "HTTPError",
                 "error_message": "403 Client Error: None for url: https://localhost/tests/test_data/v110/simple-item.json",
+                "recommendation": "For more accurate error information, rerun with --verbose.",
             }
         ]

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -20,7 +20,8 @@ def test_poorly_formatted_v090():
             ],
             "valid_stac": False,
             "error_type": "JSONSchemaValidationError",
-            "error_message": "-0.00751271 is less than the minimum of 0. Error is in properties -> view:off_nadir",
+            "error_message": "-0.00751271 is less than the minimum of 0. Error is in properties -> view:off_nadir ",
+            "recommendation": "For more accurate error information, rerun with --verbose.",
             "validation_method": "default",
             "links_validated": {
                 "format_valid": [

--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -326,9 +326,9 @@ def test_recursion_with_bad_item():
     ]
 
 
-def test_recursion_with_bad_item_verbose():
+def test_recursion_with_bad_item_trace_recursion():
     stac_file = "tests/test_data/v100/catalog-with-bad-item.json"
-    stac = stac_validator.StacValidate(stac_file, recursive=True, verbose=True)
+    stac = stac_validator.StacValidate(stac_file, recursive=True, trace_recursion=True)
     stac.run()
     assert not stac.valid
     assert len(stac.message) == 2

--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -322,6 +322,7 @@ def test_recursion_with_bad_item():
             "valid_stac": False,
             "error_type": "JSONSchemaValidationError",
             "error_message": "'id' is a required property",
+            "recommendation": "For more accurate error information, rerun with --verbose.",
         },
     ]
 
@@ -352,6 +353,7 @@ def test_recursion_with_bad_item_trace_recursion():
             "valid_stac": False,
             "error_type": "JSONSchemaValidationError",
             "error_message": "'id' is a required property",
+            "recommendation": "For more accurate error information, rerun with --verbose.",
         },
     ]
 
@@ -377,6 +379,7 @@ def test_recursion_with_bad_child_collection():
             "validation_method": "recursive",
             "error_type": "JSONSchemaValidationError",
             "error_message": "'id' is a required property",
+            "recommendation": "For more accurate error information, rerun with --verbose.",
         }
     ]
 
@@ -399,5 +402,6 @@ def test_recursion_with_missing_collection_link():
             "validation_method": "recursive",
             "error_type": "JSONSchemaValidationError",
             "error_message": "'simple-collection' should not be valid under {}. Error is in collection ",
+            "recommendation": "For more accurate error information, rerun with --verbose.",
         },
     ]


### PR DESCRIPTION
#245 
https://github.com/stac-utils/stac-check/issues/131

- Added separate `recommendation` field in error messages when running in non-verbose mode
- Verbose error messages for JSONSchemaValidationErrors
- Changed --verbose for recursive mode to --trace-recursive to make way for more comprehensive error messaging