### PR TITLE
Add speed-up recommendations, benchmark script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## [Unreleased]
 
 ### Added
 
@@ -32,6 +32,20 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 - Implemented direct dictionary passing to worker processes via pickle instead of temp file I/O [#274](https://github.com/stac-utils/stac-validator/pull/274)
 
 - Implemented pre-warming of schema cache before forking worker processes via Copy-on-Write [#274](https://github.com/stac-utils/stac-validator/pull/274)
+
+- Renamed `--feature-collection` to `--item-collection` in `batch` command to match `validate` command interface [#274](https://github.com/stac-utils/stac-validator/pull/274)
+
+- Updated batch command output format to match validate command, including all fields: version, path, schema, error_type, error_message, failed_schema, recommendation [#274](https://github.com/stac-utils/stac-validator/pull/274)
+
+- Unified validator cache control with `--schema-cache-size` option to control both fetch/parse and compiled validator caching [#274](https://github.com/stac-utils/stac-validator/pull/274)
+
+- Added input validation for `--batch-size` option (minimum value: 1) [#274](https://github.com/stac-utils/stac-validator/pull/274)
+
+### Fixed
+
+- Fixed batch command error grouping to work with new validation message format [#274](https://github.com/stac-utils/stac-validator/pull/274)
+
+- Fixed validator cache to respect runtime `--schema-cache-size` changes via dynamic cache builder [#274](https://github.com/stac-utils/stac-validator/pull/274)
 
 ## [v4.0.1] - 2026-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 
 - Implemented pre-warming of schema cache before forking worker processes via Copy-on-Write [#274](https://github.com/stac-utils/stac-validator/pull/274)
 
-- Renamed `--feature-collection` to `--item-collection` in `batch` command to match `validate` command interface [#274](https://github.com/stac-utils/stac-validator/pull/274)
+- Allow both `--feature-collection` and `--item-collection` in `batch` and `validate` command interface [#274](https://github.com/stac-utils/stac-validator/pull/274)
 
 - Updated batch command output format to match validate command, including all fields: version, path, schema, error_type, error_message, failed_schema, recommendation [#274](https://github.com/stac-utils/stac-validator/pull/274)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 ### Added
 
 - Added benchmark_validation.py script for comparing batch vs legacy validation performance
+- Added `--batch-size` option to `batch` command for configurable chunk processing (default: 2000)
+- Implemented compiled validator caching using `@functools.lru_cache` to avoid recompiling JSON schemas
+- Implemented direct dictionary passing to worker processes via pickle instead of temp file I/O
+- Implemented pre-warming of schema cache before forking worker processes via Copy-on-Write
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## Unreleased
 
 ### Added
-
-- Added benchmark_validation.py script for comparing batch vs legacy validation performance
-- Added `--batch-size` option to `batch` command for configurable chunk processing (default: 2000)
-- Implemented compiled validator caching using `@functools.lru_cache` to avoid recompiling JSON schemas
-- Implemented direct dictionary passing to worker processes via pickle instead of temp file I/O
-- Implemented pre-warming of schema cache before forking worker processes via Copy-on-Write
 
 ### Changed
 
@@ -21,6 +15,23 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 ### Removed
 
 ### Updated
+
+## [v4.1.0] - 2026-04-01
+
+### Added
+
+- Added benchmark_validation.py script for comparing batch vs legacy validation performance [#274](https://github.com/stac-utils/stac-validator/pull/274)
+
+- Added `--batch-size` option to `batch` command for configurable chunk processing (default: 2000) [#274](https://github.com/stac-utils/stac-validator/pull/274)
+
+
+### Changed
+
+- Implemented compiled validator caching using `@functools.lru_cache` to avoid recompiling JSON schemas [#274](https://github.com/stac-utils/stac-validator/pull/274)
+
+- Implemented direct dictionary passing to worker processes via pickle instead of temp file I/O [#274](https://github.com/stac-utils/stac-validator/pull/274)
+
+- Implemented pre-warming of schema cache before forking worker processes via Copy-on-Write [#274](https://github.com/stac-utils/stac-validator/pull/274)
 
 ## [v4.0.1] - 2026-03-31
 
@@ -388,7 +399,8 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 - With the newest version - 1.0.0-beta.2 - items will run through jsonchema validation before the PySTAC validation. The reason for this is that jsonschema will give more informative error messages. This should be addressed better in the future. This is not the case with the --recursive option as time can be a concern here with larger collections.
 - Logging. Various additions were made here depending on the options selected. This was done to help assist people to update their STAC collections.
 
-[Unreleased]: https://github.com/sparkgeo/stac-validator/compare/v4.0.1..main
+[Unreleased]: https://github.com/sparkgeo/stac-validator/compare/v4.1.0..main
+[v4.1.0]: https://github.com/sparkgeo/stac-validator/compare/v4.0.1..v4.1.0
 [v4.0.1]: https://github.com/sparkgeo/stac-validator/compare/v4.0.0..v4.0.1
 [v4.0.0]: https://github.com/sparkgeo/stac-validator/compare/v3.11.0..v4.0.0
 [v3.11.0]: https://github.com/sparkgeo/stac-validator/compare/v3.10.2..v3.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 
 ### Added
 
+- Added benchmark_validation.py script for comparing batch vs legacy validation performance
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -267,6 +267,9 @@ Options:
   --schema-cache-size INTEGER  Max number of schema entries to cache
                              per worker process. Use 0 to disable
                              schema caching. Defaults to 16.
+  --batch-size INTEGER         Batch size for chunked processing. Larger
+                               batches use more memory but may be faster.
+                               Defaults to 2000.
   --help                Show this message and exit.
 ```
 
@@ -306,6 +309,7 @@ $ stac-validator validate item.json --extensions --links --assets
 - `--item-collection` - Validate item collection responses
 - `--pydantic` - Use Pydantic models for validation
 - `--schema-cache-size` - Configure schema cache size
+- `--batch-size` - Configure batch size for chunked processing (batch command only)
 - And more (see `stac-validator validate --help`)
 
 #### Batch Validation
@@ -354,7 +358,24 @@ $ stac-validator batch *.json --schema-cache-size 32
 
 # Disable schema caching entirely
 $ stac-validator batch *.json --schema-cache-size 0
+
+# Configure batch size for chunked processing (default: 2000 items per chunk)
+$ stac-validator batch *.json --batch-size 5000
+
+# Use larger batch size for faster processing (uses more memory)
+$ stac-validator batch collection.json --feature-collection --batch-size 10000
+
+# Use smaller batch size for memory-constrained environments
+$ stac-validator batch *.json --batch-size 500
 ```
+
+**Batch Size Configuration**
+
+The `--batch-size` option controls how many items are processed in each chunk. This affects memory usage and performance:
+
+- **Default (2000):** Balanced memory usage and performance for most systems
+- **Larger values (5000-10000):** Faster processing on systems with abundant memory; reduces overhead from creating multiple worker pools
+- **Smaller values (500-1000):** Lower memory footprint; useful on memory-constrained systems or when validating very large items
 
 **How It Works**
 

--- a/README.md
+++ b/README.md
@@ -419,9 +419,7 @@ Validation completed in 1.10s
 
 | Scenario | Single-threaded | Batch (8 cores) | Speedup |
 |----------|-----------------|-----------------|---------|
-| 100 items | ~5 seconds | ~1 second | 5x |
-| 1000 items | ~50 seconds | ~6 seconds | 8x |
-| 10000 items | ~500 seconds | ~60 seconds | 8x |
+| 10000 items | ~130 seconds | ~22 seconds | 5.9x |
 
 *Times vary based on schema complexity and network latency for first download*
 
@@ -675,18 +673,18 @@ BENCHMARK RESULTS
 Items tested: 10000
 
 Batch Validation (multiprocessing):
-  Time: 49.02s
-  ✅ Valid: 6666
-  ❌ Invalid: 3334
+  Time: 22.43s
+  ✅ Valid: 0
+  ❌ Invalid: 10000
 
 Legacy Validation (single-threaded):
-  Time: 187.31s
-  ✅ Valid: 6666
-  ❌ Invalid: 3334
+  Time: 131.62s
+  ✅ Valid: 0
+  ❌ Invalid: 10000
 
 ======================================================================
-Speedup: 3.8x faster with batch validation
-Time saved: 138.29s
+Speedup: 5.9x faster with batch validation
+Time saved: 109.19s
 ```
 
 ### Interpreting Results

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Usage: stac-validator [OPTIONS] COMMAND [ARGS]...
   Usage:
     stac-validator validate <file> [options]
     stac-validator batch <files> [options]
-    stac-validator batch <file> --feature-collection [options]
+    stac-validator batch <file> --item-collection [options]
       
 
 Options:
@@ -247,7 +247,7 @@ Usage: stac-validator batch [OPTIONS] FILES...
       $ stac-validator batch file1.json file2.json file3.json
 
       # Validate a GeoJSON FeatureCollection (validates each feature individually)
-      $ stac-validator batch --feature-collection sample_data/sentinel-cogs_0_100.json
+      $ stac-validator batch --item-collection sample_data/sentinel-cogs_0_100.json
 
       # Use only 4 cores
       $ stac-validator batch *.json --cores 4
@@ -260,7 +260,7 @@ Options:
                         Defaults to all available cores.
   --no-progress         Disable progress bar during validation.
   --no-output           Do not print output to console.
-  --feature-collection  Treat files as GeoJSON FeatureCollections and validate
+  --item-collection  Treat files as GeoJSON FeatureCollections and validate
                         each feature individually.
   --verbose             Show full JSON output for all items. By default, only
                         invalid items are shown.
@@ -335,7 +335,7 @@ $ stac-validator batch *.json
 $ stac-validator batch item1.json item2.json item3.json
 
 # Validate a FeatureCollection (extracts and validates each feature)
-$ stac-validator batch collection.json --feature-collection
+$ stac-validator batch collection.json --item-collection
 ```
 
 **Options**
@@ -363,7 +363,7 @@ $ stac-validator batch *.json --schema-cache-size 0
 $ stac-validator batch *.json --batch-size 5000
 
 # Use larger batch size for faster processing (uses more memory)
-$ stac-validator batch collection.json --feature-collection --batch-size 10000
+$ stac-validator batch collection.json --item-collection --batch-size 10000
 
 # Use smaller batch size for memory-constrained environments
 $ stac-validator batch *.json --batch-size 500
@@ -391,7 +391,7 @@ The `--batch-size` option controls how many items are processed in each chunk. T
 **Example Output**
 
 ```bash
-$ stac-validator batch --feature-collection sample_data/sentinel-cogs_0_100.json
+$ stac-validator batch --item-collection sample_data/sentinel-cogs_0_100.json
 [
     {
         "path": "sample_data/sentinel-cogs_0_100.json[0]",

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
   - [Batch Validation](#batch-validation)
   - [Python](#python)
 - [Schema Cache Settings](#schema-cache-settings)
+- [Performance Benchmarking](#performance-benchmarking)
 - [Examples](#additional-examples)
   - [Core Validation](#--core)
   - [Custom Schema](#--custom)
@@ -619,6 +620,64 @@ Notes:
 - `StacValidate()` and `validate_dict()` do not accept a cache-size parameter.
 - Changing cache size at runtime replaces the cache instance and drops existing cached entries.
 - In multi-worker deployments, configure cache size in each worker process.
+
+## Performance Benchmarking
+
+A benchmark script is included to compare the performance of batch validation vs legacy item-collection validation. This is useful for understanding the performance improvements of the multiprocessing batch validator.
+
+### Running the Benchmark
+
+```bash
+# Test with 10,000 items (default)
+python benchmark_validation.py
+
+# Test with custom number of items
+python benchmark_validation.py --items 5000
+python benchmark_validation.py --items 50000
+
+# Run only batch validation (skip slow legacy validation)
+python benchmark_validation.py --items 10000 --batch-only
+
+# Run only legacy validation
+python benchmark_validation.py --items 10000 --legacy-only
+
+# View all options
+python benchmark_validation.py --help
+```
+
+### Example Output
+
+```
+======================================================================
+BENCHMARK RESULTS
+======================================================================
+Items tested: 10000
+
+Batch Validation (multiprocessing):
+  Time: 49.02s
+  ✅ Valid: 6666
+  ❌ Invalid: 3334
+
+Legacy Validation (single-threaded):
+  Time: 187.31s
+  ✅ Valid: 6666
+  ❌ Invalid: 3334
+
+======================================================================
+Speedup: 3.8x faster with batch validation
+Time saved: 138.29s
+```
+
+### Interpreting Results
+
+- **Speedup Factor**: Shows how many times faster batch validation is compared to legacy validation
+- **Time Saved**: The absolute time difference in seconds
+- **CPU Cores Used**: Number of CPU cores utilized by batch validation (typically all available cores)
+
+The batch validator's multiprocessing approach provides significant performance improvements, especially for large datasets. The speedup factor varies based on:
+- Number of CPU cores available
+- Size of the dataset
+- Complexity of validation (extensions, custom schemas, etc.)
 
 ## Deployment
 

--- a/benchmark_validation.py
+++ b/benchmark_validation.py
@@ -3,7 +3,7 @@
 Benchmark script comparing batch validation vs legacy item-collection validation.
 
 Compares:
-1. stac-validator batch --feature-collection (multiprocessing)
+1. stac-validator batch --item-collection (multiprocessing)
 2. stac-validator validate --item-collection (single-threaded legacy)
 
 Usage:
@@ -100,10 +100,10 @@ def generate_test_feature_collection(num_items: int = 10000) -> str:
 
 def run_batch_validation(file_path: str, batch_size: int = 2000) -> dict:
     """
-    Run batch validation with --feature-collection.
+    Run batch validation with --item-collection.
     """
     print("\n" + "=" * 70)
-    print("BENCHMARK 1: stac-validator batch --feature-collection")
+    print("BENCHMARK 1: stac-validator batch --item-collection")
     print("=" * 70)
 
     start_time = time.time()
@@ -113,7 +113,7 @@ def run_batch_validation(file_path: str, batch_size: int = 2000) -> dict:
         [
             "stac-validator",
             "batch",
-            "--feature-collection",
+            "--item-collection",
             "--batch-size",
             str(batch_size),
             file_path,
@@ -152,7 +152,7 @@ def run_batch_validation(file_path: str, batch_size: int = 2000) -> dict:
                 pass
 
     return {
-        "method": "batch --feature-collection",
+        "method": "batch --item-collection",
         "elapsed": elapsed,
         "exit_code": process.returncode,
         "output": "",

--- a/benchmark_validation.py
+++ b/benchmark_validation.py
@@ -98,7 +98,7 @@ def generate_test_feature_collection(num_items: int = 10000) -> str:
     return temp_file.name
 
 
-def run_batch_validation(file_path: str) -> dict:
+def run_batch_validation(file_path: str, batch_size: int = 2000) -> dict:
     """
     Run batch validation with --feature-collection.
     """
@@ -110,7 +110,14 @@ def run_batch_validation(file_path: str) -> dict:
 
     # Use Popen to capture output AND print it in real-time
     process = subprocess.Popen(
-        ["stac-validator", "batch", "--feature-collection", file_path],
+        [
+            "stac-validator",
+            "batch",
+            "--feature-collection",
+            "--batch-size",
+            str(batch_size),
+            file_path,
+        ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
@@ -236,6 +243,12 @@ def main():
         action="store_true",
         help="Only run legacy validation benchmark",
     )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=2000,
+        help="Batch size for chunked processing (default: 2000)",
+    )
 
     args = parser.parse_args()
 
@@ -256,7 +269,7 @@ def main():
 
         # Run batch validation if not legacy-only
         if not args.legacy_only:
-            results["batch"] = run_batch_validation(test_file)
+            results["batch"] = run_batch_validation(test_file, args.batch_size)
 
         # Run legacy validation if not batch-only
         if not args.batch_only:

--- a/benchmark_validation.py
+++ b/benchmark_validation.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""
+Benchmark script comparing batch validation vs legacy item-collection validation.
+
+Compares:
+1. stac-validator batch --feature-collection (multiprocessing)
+2. stac-validator validate --item-collection (single-threaded legacy)
+
+Usage:
+    python benchmark_validation.py --items 10000
+    python benchmark_validation.py --items 1000 --batch-only
+    python benchmark_validation.py --items 5000 --legacy-only
+"""
+
+import argparse
+import copy
+import json
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+def generate_test_feature_collection(num_items: int = 10000) -> str:
+    """
+    Generate a test GeoJSON FeatureCollection with STAC items.
+    
+    About 2/3 of items will be valid (with collection link) and 1/3 will be invalid
+    (missing collection link) to create a realistic mix.
+    
+    Args:
+        num_items: Number of items to generate
+        
+    Returns:
+        Path to the temporary GeoJSON file
+    """
+    print(f"Generating test FeatureCollection with {num_items} items...")
+    
+    # Load a sample item
+    sample_item_path = Path(__file__).parent / "sample_data" / "sentinel-cogs-test.json"
+    if not sample_item_path.exists():
+        print(f"Error: Sample item not found at {sample_item_path}")
+        sys.exit(1)
+    
+    with open(sample_item_path) as f:
+        sample_item = json.load(f)
+    
+    # Create a FeatureCollection with a mix of valid and invalid items
+    features = []
+    valid_count = 0
+    invalid_count = 0
+    
+    for i in range(num_items):
+        item = copy.deepcopy(sample_item)
+        item["id"] = f"{item.get('id', 'item')}-{i}"
+        
+        # Make ~2/3 of items valid by adding a collection link
+        if i % 3 != 0:  # 2 out of 3 items
+            # Add a collection link if it doesn't exist
+            if "links" not in item:
+                item["links"] = []
+            else:
+                # Deep copy the links list to avoid modifying the original
+                item["links"] = copy.deepcopy(item["links"])
+            
+            # Check if collection link already exists
+            has_collection_link = any(
+                link.get("rel") == "collection" for link in item.get("links", [])
+            )
+            
+            if not has_collection_link:
+                item["links"].append({
+                    "rel": "collection",
+                    "href": f"https://example.com/collections/{item.get('collection', 'unknown')}",
+                    "type": "application/json"
+                })
+            valid_count += 1
+        else:
+            # Keep ~1/3 of items invalid (missing collection link)
+            invalid_count += 1
+        
+        features.append(item)
+    
+    feature_collection = {
+        "type": "FeatureCollection",
+        "features": features
+    }
+    
+    # Write to temporary file
+    temp_file = tempfile.NamedTemporaryFile(
+        mode='w',
+        suffix='.json',
+        delete=False
+    )
+    json.dump(feature_collection, temp_file)
+    temp_file.close()
+    
+    print(f"Test FeatureCollection created: {temp_file.name}")
+    print(f"  Valid items (with collection link): {valid_count}")
+    print(f"  Invalid items (missing collection link): {invalid_count}")
+    return temp_file.name
+
+
+def run_batch_validation(file_path: str) -> dict:
+    """
+    Run batch validation with --feature-collection.
+    """
+    print("\n" + "="*70)
+    print("BENCHMARK 1: stac-validator batch --feature-collection")
+    print("="*70)
+    
+    start_time = time.time()
+    
+    # Use Popen to capture output AND print it in real-time
+    process = subprocess.Popen(
+        [
+            "stac-validator",
+            "batch",
+            "--feature-collection",
+            file_path
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        universal_newlines=True
+    )
+    
+    output_lines = []
+    # Read output line-by-line as it's generated
+    for line in process.stdout:
+        sys.stdout.write(line)
+        sys.stdout.flush()
+        output_lines.append(line)
+        
+    process.wait()
+    elapsed = time.time() - start_time
+    
+    # Parse the output to extract valid/invalid counts
+    valid_count = 0
+    invalid_count = 0
+    
+    for line in output_lines:
+        if '✅ Valid:' in line:
+            try:
+                valid_count = int(line.split('✅ Valid:')[1].split()[0])
+            except (IndexError, ValueError):
+                pass
+        elif '❌ Invalid:' in line:
+            try:
+                invalid_count = int(line.split('❌ Invalid:')[1].split()[0])
+            except (IndexError, ValueError):
+                pass
+    
+    return {
+        "method": "batch --feature-collection",
+        "elapsed": elapsed,
+        "exit_code": process.returncode,
+        "output": "",
+        "valid_count": valid_count,
+        "invalid_count": invalid_count
+    }
+
+
+def run_legacy_validation(file_path: str) -> dict:
+    """
+    Run legacy validation with --item-collection.
+    """
+    print("\n" + "="*70)
+    print("BENCHMARK 2: stac-validator validate --item-collection")
+    print("="*70)
+    
+    start_time = time.time()
+    
+    # Use Popen to capture output AND print it in real-time
+    process = subprocess.Popen(
+        [
+            "stac-validator",
+            "validate",
+            "--item-collection",
+            file_path
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        universal_newlines=True
+    )
+    
+    output_lines = []
+    # Read output line-by-line as it's generated
+    for line in process.stdout:
+        sys.stdout.write(line)
+        sys.stdout.flush()
+        output_lines.append(line)
+        
+    process.wait()
+    elapsed = time.time() - start_time
+    
+    # Parse output to extract valid/invalid counts
+    valid_count = 0
+    invalid_count = 0
+    
+    for line in output_lines:
+        if 'Items passed:' in line:
+            try:
+                passed_part = line.split('Items passed:')[1].strip()
+                parts = passed_part.split('/')
+                valid_count = int(parts[0].strip())
+                total_str = parts[1].split('(')[0].strip()
+                total = int(total_str)
+                invalid_count = total - valid_count
+            except (IndexError, ValueError):
+                pass
+    
+    return {
+        "method": "validate --item-collection",
+        "elapsed": elapsed,
+        "exit_code": process.returncode,
+        "output": "",
+        "valid_count": valid_count,
+        "invalid_count": invalid_count
+    }
+
+def main():
+    """Run the benchmark comparison."""
+    parser = argparse.ArgumentParser(
+        description="Benchmark batch validation vs legacy item-collection validation",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python benchmark_validation.py --items 10000
+  python benchmark_validation.py --items 1000 --batch-only
+  python benchmark_validation.py --items 5000 --legacy-only
+        """
+    )
+    parser.add_argument(
+        "--items",
+        type=int,
+        default=10000,
+        help="Number of items to test (default: 10000)"
+    )
+    parser.add_argument(
+        "--batch-only",
+        action="store_true",
+        help="Only run batch validation benchmark"
+    )
+    parser.add_argument(
+        "--legacy-only",
+        action="store_true",
+        help="Only run legacy validation benchmark"
+    )
+    
+    args = parser.parse_args()
+    
+    # Validate arguments
+    if args.batch_only and args.legacy_only:
+        print("Error: Cannot specify both --batch-only and --legacy-only")
+        sys.exit(1)
+    
+    if args.items < 1:
+        print("Error: --items must be at least 1")
+        sys.exit(1)
+    
+    # Generate test data
+    test_file = generate_test_feature_collection(args.items)
+    
+    try:
+        results = {}
+        
+        # Run batch validation if not legacy-only
+        if not args.legacy_only:
+            results['batch'] = run_batch_validation(test_file)
+        
+        # Run legacy validation if not batch-only
+        if not args.batch_only:
+            results['legacy'] = run_legacy_validation(test_file)
+        
+        # Print comparison
+        print("\n" + "="*70)
+        print("BENCHMARK RESULTS")
+        print("="*70)
+        print(f"Items tested: {args.items}")
+        
+        if 'batch' in results:
+            batch_result = results['batch']
+            print(f"\nBatch Validation (multiprocessing):")
+            print(f"  Time: {batch_result['elapsed']:.2f}s")
+            print(f"  ✅ Valid: {batch_result.get('valid_count', 0)}")
+            print(f"  ❌ Invalid: {batch_result.get('invalid_count', 0)}")
+        
+        if 'legacy' in results:
+            legacy_result = results['legacy']
+            print(f"\nLegacy Validation (single-threaded):")
+            print(f"  Time: {legacy_result['elapsed']:.2f}s")
+            print(f"  ✅ Valid: {legacy_result.get('valid_count', 0)}")
+            print(f"  ❌ Invalid: {legacy_result.get('invalid_count', 0)}")
+        
+        # Calculate speedup if both ran
+        if 'batch' in results and 'legacy' in results:
+            speedup = legacy_result['elapsed'] / batch_result['elapsed']
+            print(f"\n{'='*70}")
+            print(f"Speedup: {speedup:.1f}x faster with batch validation")
+            print(f"Time saved: {legacy_result['elapsed'] - batch_result['elapsed']:.2f}s")
+        
+    finally:
+        # Clean up
+        import os
+        os.unlink(test_file)
+        print(f"\nCleaned up test file: {test_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark_validation.py
+++ b/benchmark_validation.py
@@ -15,6 +15,7 @@ Usage:
 import argparse
 import copy
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -25,36 +26,36 @@ from pathlib import Path
 def generate_test_feature_collection(num_items: int = 10000) -> str:
     """
     Generate a test GeoJSON FeatureCollection with STAC items.
-    
+
     About 2/3 of items will be valid (with collection link) and 1/3 will be invalid
     (missing collection link) to create a realistic mix.
-    
+
     Args:
         num_items: Number of items to generate
-        
+
     Returns:
         Path to the temporary GeoJSON file
     """
     print(f"Generating test FeatureCollection with {num_items} items...")
-    
+
     # Load a sample item
     sample_item_path = Path(__file__).parent / "sample_data" / "sentinel-cogs-test.json"
     if not sample_item_path.exists():
         print(f"Error: Sample item not found at {sample_item_path}")
         sys.exit(1)
-    
+
     with open(sample_item_path) as f:
         sample_item = json.load(f)
-    
+
     # Create a FeatureCollection with a mix of valid and invalid items
     features = []
     valid_count = 0
     invalid_count = 0
-    
+
     for i in range(num_items):
         item = copy.deepcopy(sample_item)
         item["id"] = f"{item.get('id', 'item')}-{i}"
-        
+
         # Make ~2/3 of items valid by adding a collection link
         if i % 3 != 0:  # 2 out of 3 items
             # Add a collection link if it doesn't exist
@@ -63,39 +64,34 @@ def generate_test_feature_collection(num_items: int = 10000) -> str:
             else:
                 # Deep copy the links list to avoid modifying the original
                 item["links"] = copy.deepcopy(item["links"])
-            
+
             # Check if collection link already exists
             has_collection_link = any(
                 link.get("rel") == "collection" for link in item.get("links", [])
             )
-            
+
             if not has_collection_link:
-                item["links"].append({
-                    "rel": "collection",
-                    "href": f"https://example.com/collections/{item.get('collection', 'unknown')}",
-                    "type": "application/json"
-                })
+                item["links"].append(
+                    {
+                        "rel": "collection",
+                        "href": f"https://example.com/collections/{item.get('collection', 'unknown')}",
+                        "type": "application/json",
+                    }
+                )
             valid_count += 1
         else:
             # Keep ~1/3 of items invalid (missing collection link)
             invalid_count += 1
-        
+
         features.append(item)
-    
-    feature_collection = {
-        "type": "FeatureCollection",
-        "features": features
-    }
-    
+
+    feature_collection = {"type": "FeatureCollection", "features": features}
+
     # Write to temporary file
-    temp_file = tempfile.NamedTemporaryFile(
-        mode='w',
-        suffix='.json',
-        delete=False
-    )
+    temp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
     json.dump(feature_collection, temp_file)
     temp_file.close()
-    
+
     print(f"Test FeatureCollection created: {temp_file.name}")
     print(f"  Valid items (with collection link): {valid_count}")
     print(f"  Invalid items (missing collection link): {invalid_count}")
@@ -106,60 +102,55 @@ def run_batch_validation(file_path: str) -> dict:
     """
     Run batch validation with --feature-collection.
     """
-    print("\n" + "="*70)
+    print("\n" + "=" * 70)
     print("BENCHMARK 1: stac-validator batch --feature-collection")
-    print("="*70)
-    
+    print("=" * 70)
+
     start_time = time.time()
-    
+
     # Use Popen to capture output AND print it in real-time
     process = subprocess.Popen(
-        [
-            "stac-validator",
-            "batch",
-            "--feature-collection",
-            file_path
-        ],
+        ["stac-validator", "batch", "--feature-collection", file_path],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
         bufsize=1,
-        universal_newlines=True
+        universal_newlines=True,
     )
-    
+
     output_lines = []
     # Read output line-by-line as it's generated
     for line in process.stdout:
         sys.stdout.write(line)
         sys.stdout.flush()
         output_lines.append(line)
-        
+
     process.wait()
     elapsed = time.time() - start_time
-    
+
     # Parse the output to extract valid/invalid counts
     valid_count = 0
     invalid_count = 0
-    
+
     for line in output_lines:
-        if '✅ Valid:' in line:
+        if "✅ Valid:" in line:
             try:
-                valid_count = int(line.split('✅ Valid:')[1].split()[0])
+                valid_count = int(line.split("✅ Valid:")[1].split()[0])
             except (IndexError, ValueError):
                 pass
-        elif '❌ Invalid:' in line:
+        elif "❌ Invalid:" in line:
             try:
-                invalid_count = int(line.split('❌ Invalid:')[1].split()[0])
+                invalid_count = int(line.split("❌ Invalid:")[1].split()[0])
             except (IndexError, ValueError):
                 pass
-    
+
     return {
         "method": "batch --feature-collection",
         "elapsed": elapsed,
         "exit_code": process.returncode,
         "output": "",
         "valid_count": valid_count,
-        "invalid_count": invalid_count
+        "invalid_count": invalid_count,
     }
 
 
@@ -167,61 +158,57 @@ def run_legacy_validation(file_path: str) -> dict:
     """
     Run legacy validation with --item-collection.
     """
-    print("\n" + "="*70)
+    print("\n" + "=" * 70)
     print("BENCHMARK 2: stac-validator validate --item-collection")
-    print("="*70)
-    
+    print("=" * 70)
+
     start_time = time.time()
-    
+
     # Use Popen to capture output AND print it in real-time
     process = subprocess.Popen(
-        [
-            "stac-validator",
-            "validate",
-            "--item-collection",
-            file_path
-        ],
+        ["stac-validator", "validate", "--item-collection", file_path],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
         bufsize=1,
-        universal_newlines=True
+        universal_newlines=True,
     )
-    
+
     output_lines = []
     # Read output line-by-line as it's generated
     for line in process.stdout:
         sys.stdout.write(line)
         sys.stdout.flush()
         output_lines.append(line)
-        
+
     process.wait()
     elapsed = time.time() - start_time
-    
+
     # Parse output to extract valid/invalid counts
     valid_count = 0
     invalid_count = 0
-    
+
     for line in output_lines:
-        if 'Items passed:' in line:
+        if "Items passed:" in line:
             try:
-                passed_part = line.split('Items passed:')[1].strip()
-                parts = passed_part.split('/')
+                passed_part = line.split("Items passed:")[1].strip()
+                parts = passed_part.split("/")
                 valid_count = int(parts[0].strip())
-                total_str = parts[1].split('(')[0].strip()
+                total_str = parts[1].split("(")[0].strip()
                 total = int(total_str)
                 invalid_count = total - valid_count
             except (IndexError, ValueError):
                 pass
-    
+
     return {
         "method": "validate --item-collection",
         "elapsed": elapsed,
         "exit_code": process.returncode,
         "output": "",
         "valid_count": valid_count,
-        "invalid_count": invalid_count
+        "invalid_count": invalid_count,
     }
+
 
 def main():
     """Run the benchmark comparison."""
@@ -229,84 +216,83 @@ def main():
         description="Benchmark batch validation vs legacy item-collection validation",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
-Examples:
-  python benchmark_validation.py --items 10000
-  python benchmark_validation.py --items 1000 --batch-only
-  python benchmark_validation.py --items 5000 --legacy-only
-        """
+        Examples:
+        python benchmark_validation.py --items 10000
+        python benchmark_validation.py --items 1000 --batch-only
+        python benchmark_validation.py --items 5000 --legacy-only
+                """,
     )
     parser.add_argument(
         "--items",
         type=int,
         default=10000,
-        help="Number of items to test (default: 10000)"
+        help="Number of items to test (default: 10000)",
     )
     parser.add_argument(
-        "--batch-only",
-        action="store_true",
-        help="Only run batch validation benchmark"
+        "--batch-only", action="store_true", help="Only run batch validation benchmark"
     )
     parser.add_argument(
         "--legacy-only",
         action="store_true",
-        help="Only run legacy validation benchmark"
+        help="Only run legacy validation benchmark",
     )
-    
+
     args = parser.parse_args()
-    
+
     # Validate arguments
     if args.batch_only and args.legacy_only:
         print("Error: Cannot specify both --batch-only and --legacy-only")
         sys.exit(1)
-    
+
     if args.items < 1:
         print("Error: --items must be at least 1")
         sys.exit(1)
-    
+
     # Generate test data
     test_file = generate_test_feature_collection(args.items)
-    
+
     try:
         results = {}
-        
+
         # Run batch validation if not legacy-only
         if not args.legacy_only:
-            results['batch'] = run_batch_validation(test_file)
-        
+            results["batch"] = run_batch_validation(test_file)
+
         # Run legacy validation if not batch-only
         if not args.batch_only:
-            results['legacy'] = run_legacy_validation(test_file)
-        
+            results["legacy"] = run_legacy_validation(test_file)
+
         # Print comparison
-        print("\n" + "="*70)
+        print("\n" + "=" * 70)
         print("BENCHMARK RESULTS")
-        print("="*70)
+        print("=" * 70)
         print(f"Items tested: {args.items}")
-        
-        if 'batch' in results:
-            batch_result = results['batch']
-            print(f"\nBatch Validation (multiprocessing):")
+
+        if "batch" in results:
+            batch_result = results["batch"]
+            print("\nBatch Validation (multiprocessing):")
             print(f"  Time: {batch_result['elapsed']:.2f}s")
             print(f"  ✅ Valid: {batch_result.get('valid_count', 0)}")
             print(f"  ❌ Invalid: {batch_result.get('invalid_count', 0)}")
-        
-        if 'legacy' in results:
-            legacy_result = results['legacy']
-            print(f"\nLegacy Validation (single-threaded):")
+
+        if "legacy" in results:
+            legacy_result = results["legacy"]
+            print("\nLegacy Validation (single-threaded):")
             print(f"  Time: {legacy_result['elapsed']:.2f}s")
             print(f"  ✅ Valid: {legacy_result.get('valid_count', 0)}")
             print(f"  ❌ Invalid: {legacy_result.get('invalid_count', 0)}")
-        
+
         # Calculate speedup if both ran
-        if 'batch' in results and 'legacy' in results:
-            speedup = legacy_result['elapsed'] / batch_result['elapsed']
-            print(f"\n{'='*70}")
+        if "batch" in results and "legacy" in results:
+            speedup = legacy_result["elapsed"] / batch_result["elapsed"]
+            print(f"\n{'=' * 70}")
             print(f"Speedup: {speedup:.1f}x faster with batch validation")
-            print(f"Time saved: {legacy_result['elapsed'] - batch_result['elapsed']:.2f}s")
-        
+            print(
+                f"Time saved: {legacy_result['elapsed'] - batch_result['elapsed']:.2f}s"
+            )
+
     finally:
         # Clean up
-        import os
         os.unlink(test_file)
         print(f"\nCleaned up test file: {test_file}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "stac_validator"
-version = "4.0.1"
+version = "4.1.0"
 description = "A package to validate STAC files"
 authors = [
     {name = "James Banting"},

--- a/sample_data/sentinel-cogs-test.json
+++ b/sample_data/sentinel-cogs-test.json
@@ -53,6 +53,7 @@
                 "sentinel:product_id": "S2B_MSIL2A_20191211T161339_N0213_R111_T01CDH_20191211T195221",
                 "sentinel:data_coverage": 0.0,
                 "eo:cloud_cover": 0.0,
+                "eo:bands": [],
                 "sentinel:valid_cloud_cover": true,
                 "proj:centroid": {
                     "lat": -82.84867670781385,

--- a/stac_validator/batch_validator.py
+++ b/stac_validator/batch_validator.py
@@ -398,7 +398,7 @@ def _chunked_iterable(iterable: Iterable, size: int):
 def validate_dicts(
     items: Iterable[Dict[str, Any]],
     max_workers: Optional[int] = None,
-    show_progress: bool = True,
+    show_progress: bool = False,
     chunk_size: int = 2000,
 ) -> List[Dict[str, Any]]:
     """
@@ -415,7 +415,7 @@ def validate_dicts(
             - None or 0: Use all available cores (default)
             - Positive int: Use that many cores (capped at available)
             - Negative int: Use all cores minus that many
-        show_progress: Whether to show progress bar (default: True)
+        show_progress: Whether to show progress bar (default: False). Set to True for CLI usage.
         chunk_size: Number of items to process at a time to bound memory usage.
 
     Returns:

--- a/stac_validator/batch_validator.py
+++ b/stac_validator/batch_validator.py
@@ -2,6 +2,7 @@
 
 import concurrent.futures
 import json
+import logging
 import multiprocessing
 from itertools import islice
 from typing import Any, Dict, Iterable, List, Optional, Tuple
@@ -9,8 +10,10 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 from .utilities import _build_cached_validator
 from .validate import StacValidate
 
+logger = logging.getLogger(__name__)
 
-def _warm_schema_cache() -> None:
+
+def _warm_schema_cache(stac_version: str = "1.0.0") -> None:
     """
     Pre-warm the schema cache before forking worker processes.
 
@@ -19,35 +22,44 @@ def _warm_schema_cache() -> None:
     memory via Copy-on-Write (CoW), so all workers get a fully-warmed cache
     without making any network requests.
 
+    Args:
+        stac_version: STAC version to use for schema selection (e.g., "1.0.0" or "1.1.0")
+
     Core schemas warmed:
-    - STAC Item (v1.0.0)
-    - STAC Collection (v1.0.0)
-    - STAC Catalog (v1.0.0)
+    - STAC Item
+    - STAC Collection
+    - STAC Catalog
     """
     try:
-        # Core STAC schema URLs that are commonly used
+        import os
+
+        # Use local schema files bundled with the package
+        # Support both v1.0.0 and v1.1.0
+        schema_dir = os.path.join(
+            os.path.dirname(__file__), "local_schemas", stac_version
+        )
+
         core_schemas = [
-            "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json",
-            "https://schemas.stacspec.org/v1.0.0/collection-spec/v1.0.0/collection.json",
-            "https://schemas.stacspec.org/v1.0.0/catalog-spec/v1.0.0/catalog.json",
+            os.path.join(schema_dir, "item.json"),
+            os.path.join(schema_dir, "collection.json"),
+            os.path.join(schema_dir, "catalog.json"),
         ]
 
         from .utilities import fetch_and_parse_schema
 
-        # Fetch and parse each schema to populate the cache
-        for schema_url in core_schemas:
+        # Load and cache each schema
+        for schema_path in core_schemas:
             try:
-                schema = fetch_and_parse_schema(schema_url)
+                schema = fetch_and_parse_schema(schema_path)
                 # Convert to JSON string and cache via _build_cached_validator
                 schema_json = json.dumps(schema, sort_keys=True, separators=(",", ":"))
                 _build_cached_validator(schema_json)
             except Exception:
                 # If a schema fails to load, continue with others
-                # This ensures partial cache warming even if some schemas are unavailable
                 pass
+
     except Exception:
         # If cache warming fails entirely, continue without it
-        # The validators will still work, just without the pre-warmed cache
         pass
 
 
@@ -151,7 +163,7 @@ def _validate_single_file(file_path: str) -> Tuple[str, bool, List[str]]:
 
 def _validate_dict(
     item_dict: Dict[str, Any], source_path: str
-) -> Tuple[str, bool, List[str]]:
+) -> Tuple[str, bool, List[Dict[str, str]], str]:
     """
     Worker function that validates a STAC item dictionary directly (no temp files).
 
@@ -163,9 +175,11 @@ def _validate_dict(
         source_path: Display path for result reporting (e.g., "file.json[0]").
 
     Returns:
-        Tuple of (source_path, is_valid, list_of_errors)
+        Tuple of (source_path, is_valid, list_of_error_dicts, item_id)
+        where error_dicts contain 'message' and 'schema' keys
     """
     errors = []
+    item_id = item_dict.get("id", "unknown")
 
     try:
         # Validate the dictionary directly without writing to disk
@@ -186,26 +200,50 @@ def _validate_dict(
                 if isinstance(messages, list) and len(messages) > 0:
                     msg_obj = messages[0]
                     if not msg_obj.get("valid_stac", False):
+                        # Extract schema information - prefer failed_schema, then schema field
+                        failed_schema = msg_obj.get("failed_schema", "")
+                        if not failed_schema:
+                            # Try to get from schema field (list of schemas checked)
+                            schema_list = msg_obj.get("schema", [])
+                            # Use the last schema in the list (most likely the one that failed)
+                            failed_schema = schema_list[-1] if schema_list else ""
+
                         # Try multiple error field names
                         if "errors" in msg_obj:
-                            errors.extend(msg_obj["errors"])
+                            for error_msg in msg_obj["errors"]:
+                                errors.append(
+                                    {"message": error_msg, "schema": failed_schema}
+                                )
                         elif "error_message" in msg_obj:
-                            errors.append(msg_obj["error_message"])
+                            errors.append(
+                                {
+                                    "message": msg_obj["error_message"],
+                                    "schema": failed_schema,
+                                }
+                            )
                         else:
                             errors.append(
-                                f"{msg_obj.get('error_type', 'ValidationError')}"
+                                {
+                                    "message": f"{msg_obj.get('error_type', 'ValidationError')}",
+                                    "schema": failed_schema,
+                                }
                             )
             except (KeyError, IndexError, TypeError):
                 # If we can't parse, just use the raw message
                 if validator.message:
-                    errors.append(str(validator.message))
+                    errors.append({"message": str(validator.message), "schema": ""})
 
     except Exception as e:
         # Catch any exception during validation
-        return source_path, False, [f"Critical error processing item: {str(e)}"]
+        return (
+            source_path,
+            False,
+            [{"message": f"Critical error processing item: {str(e)}", "schema": ""}],
+            item_id,
+        )
 
     is_valid = len(errors) == 0
-    return source_path, is_valid, errors
+    return source_path, is_valid, errors, item_id
 
 
 def validate_concurrently(
@@ -235,10 +273,6 @@ def validate_concurrently(
     Returns:
         List of result dictionaries with keys: path, valid_stac, errors
     """
-    # Pre-warm the schema cache in the main process before forking workers
-    # This leverages Copy-on-Write so all workers inherit the warmed cache
-    _warm_schema_cache()
-
     # If feature_collection mode, extract features and delegate to validate_dicts
     # for memory-safe chunked processing
     if feature_collection:
@@ -284,6 +318,7 @@ def validate_concurrently(
                     )
 
         # Delegate to validate_dicts for chunked, memory-safe processing
+        # validate_dicts will detect STAC version from first item and warm cache
         validation_results = validate_dicts(
             item_iter(),
             max_workers=max_workers,
@@ -386,10 +421,6 @@ def validate_dicts(
     Returns:
         List of validation results with path, valid_stac, and errors (if any)
     """
-    # Pre-warm the schema cache in the main process before forking workers
-    # This leverages Copy-on-Write so all workers inherit the warmed cache
-    _warm_schema_cache()
-
     all_results = []
 
     try:
@@ -402,8 +433,19 @@ def validate_dicts(
 
     optimal_workers = get_optimal_worker_count(max_workers)
 
+    # Detect STAC version from first item and warm cache accordingly
+    stac_version = "1.0.0"  # default
+    items_list = list(items)
+    if items_list:
+        first_item = items_list[0]
+        stac_version = first_item.get("stac_version", "1.0.0")
+
+    # Pre-warm the schema cache in the main process before forking workers
+    # This leverages Copy-on-Write so all workers inherit the warmed cache
+    _warm_schema_cache(stac_version=stac_version)
+
     # Process items in bounded chunks to protect memory
-    for chunk in _chunked_iterable(items, chunk_size):
+    for chunk in _chunked_iterable(items_list, chunk_size):
         chunk_list = list(chunk)
         if not chunk_list:
             continue
@@ -454,11 +496,12 @@ def validate_dicts(
                 # Collect results as they finish
                 for future in iterator:
                     display_path, idx = future_to_item[future]
-                    source_path, is_valid, errors = future.result()
+                    source_path, is_valid, errors, item_id = future.result()
 
                     result = {
                         "path": source_path,
                         "valid_stac": is_valid,
+                        "item_id": item_id,
                     }
 
                     if errors:

--- a/stac_validator/batch_validator.py
+++ b/stac_validator/batch_validator.py
@@ -444,20 +444,32 @@ def validate_dicts(
     # This leverages Copy-on-Write so all workers inherit the warmed cache
     _warm_schema_cache(stac_version=stac_version)
 
-    # Process items in bounded chunks to protect memory
-    for chunk in _chunked_iterable(items_list, chunk_size):
-        chunk_list = list(chunk)
-        if not chunk_list:
-            continue
+    # Create a single executor for the entire run to reuse workers across chunks
+    # This preserves the schema cache across chunks and eliminates fork/spawn overhead
+    try:
+        with concurrent.futures.ProcessPoolExecutor(
+            max_workers=optimal_workers
+        ) as executor:
+            total_items = len(items_list)
+            progress_bar = None
 
-        try:
-            with concurrent.futures.ProcessPoolExecutor(
-                max_workers=optimal_workers
-            ) as executor:
-                # Submit all items in chunk to the pool
-                # Pass dictionaries directly via pickle (no temp files)
+            # Initialize progress bar if available
+            if show_progress and has_tqdm:
+                progress_bar = tqdm(  # type: ignore
+                    total=total_items,
+                    desc="Validating Items",
+                    unit="item",
+                )
+
+            # Process items in chunks: submit a chunk, collect results, then submit next
+            # This bounds in-flight futures and memory usage while reusing workers
+            for chunk in _chunked_iterable(items_list, chunk_size):
+                if not chunk:
+                    continue
+
+                # Submit all items in this chunk
                 future_to_item = {}
-                for idx, item in enumerate(chunk_list):
+                for idx, item in enumerate(chunk):
                     # Extract source metadata if present
                     source_file = item.get("__source_file__")
                     feature_index = item.get("__feature_index__")
@@ -483,18 +495,8 @@ def validate_dicts(
                     future = executor.submit(_validate_dict, payload, display_path)
                     future_to_item[future] = (display_path, idx)
 
-                # Wrap iterator with tqdm for progress bar
-                iterator = concurrent.futures.as_completed(future_to_item)
-                if show_progress and has_tqdm:
-                    iterator = tqdm(  # type: ignore
-                        iterator,
-                        total=len(chunk_list),
-                        desc="Validating Items",
-                        unit="item",
-                    )
-
-                # Collect results as they finish
-                for future in iterator:
+                # Collect results for this chunk as they finish
+                for future in concurrent.futures.as_completed(future_to_item):
                     display_path, idx = future_to_item[future]
                     source_path, is_valid, errors, item_id = future.result()
 
@@ -509,27 +511,35 @@ def validate_dicts(
 
                     all_results.append(result)
 
-        except Exception as e:
-            # If chunk processing fails, record error for all items in chunk
-            for idx, item in enumerate(chunk_list):
-                source_file = item.get("__source_file__")
-                feature_index = item.get("__feature_index__")
+                    # Update progress bar
+                    if progress_bar:
+                        progress_bar.update(1)
 
-                if source_file is not None:
-                    display_path = (
-                        f"{source_file}[{feature_index}]"
-                        if feature_index is not None
-                        else source_file
-                    )
-                else:
-                    display_path = f"item-{idx}"
+            # Close progress bar
+            if progress_bar:
+                progress_bar.close()
 
-                all_results.append(
-                    {
-                        "path": display_path,
-                        "valid_stac": False,
-                        "errors": [f"Chunk processing error: {str(e)}"],
-                    }
+    except Exception as e:
+        # If processing fails, record error for all items
+        for idx, item in enumerate(items_list):
+            source_file = item.get("__source_file__")
+            feature_index = item.get("__feature_index__")
+
+            if source_file is not None:
+                display_path = (
+                    f"{source_file}[{feature_index}]"
+                    if feature_index is not None
+                    else source_file
                 )
+            else:
+                display_path = f"item-{idx}"
+
+            all_results.append(
+                {
+                    "path": display_path,
+                    "valid_stac": False,
+                    "errors": [f"Chunk processing error: {str(e)}"],
+                }
+            )
 
     return all_results

--- a/stac_validator/batch_validator.py
+++ b/stac_validator/batch_validator.py
@@ -163,7 +163,7 @@ def _validate_single_file(file_path: str) -> Tuple[str, bool, List[str]]:
 
 def _validate_dict(
     item_dict: Dict[str, Any], source_path: str
-) -> Tuple[str, bool, List[Dict[str, str]], str]:
+) -> Tuple[str, bool, Dict[str, Any], str]:
     """
     Worker function that validates a STAC item dictionary directly (no temp files).
 
@@ -175,11 +175,11 @@ def _validate_dict(
         source_path: Display path for result reporting (e.g., "file.json[0]").
 
     Returns:
-        Tuple of (source_path, is_valid, list_of_error_dicts, item_id)
-        where error_dicts contain 'message' and 'schema' keys
+        Tuple of (source_path, is_valid, message_dict, item_id)
+        where message_dict is the complete validation result from StacValidate
     """
-    errors = []
     item_id = item_dict.get("id", "unknown")
+    message = {}
 
     try:
         # Validate the dictionary directly without writing to disk
@@ -193,57 +193,29 @@ def _validate_dict(
         # Run validation on the dictionary
         validator.validate_dict(item_dict)
 
-        # Collect errors from validation
+        # Get the validation result message
         if validator.message:
-            try:
-                messages = validator.message
-                if isinstance(messages, list) and len(messages) > 0:
-                    msg_obj = messages[0]
-                    if not msg_obj.get("valid_stac", False):
-                        # Extract schema information - prefer failed_schema, then schema field
-                        failed_schema = msg_obj.get("failed_schema", "")
-                        if not failed_schema:
-                            # Try to get from schema field (list of schemas checked)
-                            schema_list = msg_obj.get("schema", [])
-                            # Use the last schema in the list (most likely the one that failed)
-                            failed_schema = schema_list[-1] if schema_list else ""
-
-                        # Try multiple error field names
-                        if "errors" in msg_obj:
-                            for error_msg in msg_obj["errors"]:
-                                errors.append(
-                                    {"message": error_msg, "schema": failed_schema}
-                                )
-                        elif "error_message" in msg_obj:
-                            errors.append(
-                                {
-                                    "message": msg_obj["error_message"],
-                                    "schema": failed_schema,
-                                }
-                            )
-                        else:
-                            errors.append(
-                                {
-                                    "message": f"{msg_obj.get('error_type', 'ValidationError')}",
-                                    "schema": failed_schema,
-                                }
-                            )
-            except (KeyError, IndexError, TypeError):
-                # If we can't parse, just use the raw message
-                if validator.message:
-                    errors.append({"message": str(validator.message), "schema": ""})
+            messages = validator.message
+            if isinstance(messages, list) and len(messages) > 0:
+                message = messages[0]
+            else:
+                message = messages if isinstance(messages, dict) else {}
+            
+            # Set path to the display path (not a real file)
+            message["path"] = source_path
 
     except Exception as e:
         # Catch any exception during validation
-        return (
-            source_path,
-            False,
-            [{"message": f"Critical error processing item: {str(e)}", "schema": ""}],
-            item_id,
-        )
+        message = {
+            "path": source_path,
+            "valid_stac": False,
+            "error_type": "Exception",
+            "error_message": f"Critical error processing item: {str(e)}",
+            "failed_schema": "",
+        }
 
-    is_valid = len(errors) == 0
-    return source_path, is_valid, errors, item_id
+    is_valid = message.get("valid_stac", False)
+    return source_path, is_valid, message, item_id
 
 
 def validate_concurrently(
@@ -498,16 +470,19 @@ def validate_dicts(
                 # Collect results for this chunk as they finish
                 for future in concurrent.futures.as_completed(future_to_item):
                     display_path, idx = future_to_item[future]
-                    source_path, is_valid, errors, item_id = future.result()
+                    source_path, is_valid, message, item_id = future.result()
 
-                    result = {
-                        "path": source_path,
-                        "valid_stac": is_valid,
-                        "item_id": item_id,
-                    }
-
-                    if errors:
-                        result["errors"] = errors
+                    # Use the complete message from validation
+                    result = message.copy() if message else {}
+                    
+                    # Ensure required fields are present
+                    if "path" not in result:
+                        result["path"] = source_path
+                    if "valid_stac" not in result:
+                        result["valid_stac"] = is_valid
+                    
+                    # Add item_id for reference
+                    result["item_id"] = item_id
 
                     all_results.append(result)
 

--- a/stac_validator/batch_validator.py
+++ b/stac_validator/batch_validator.py
@@ -200,7 +200,7 @@ def _validate_dict(
                 message = messages[0]
             else:
                 message = messages if isinstance(messages, dict) else {}
-            
+
             # Set path to the display path (not a real file)
             message["path"] = source_path
 
@@ -474,13 +474,13 @@ def validate_dicts(
 
                     # Use the complete message from validation
                     result = message.copy() if message else {}
-                    
+
                     # Ensure required fields are present
                     if "path" not in result:
                         result["path"] = source_path
                     if "valid_stac" not in result:
                         result["valid_stac"] = is_valid
-                    
+
                     # Add item_id for reference
                     result["item_id"] = item_id
 

--- a/stac_validator/batch_validator.py
+++ b/stac_validator/batch_validator.py
@@ -3,12 +3,52 @@
 import concurrent.futures
 import json
 import multiprocessing
-import os
-import tempfile
 from itertools import islice
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
+from .utilities import _build_cached_validator
 from .validate import StacValidate
+
+
+def _warm_schema_cache() -> None:
+    """
+    Pre-warm the schema cache before forking worker processes.
+
+    This function loads and compiles core STAC schemas in the main process.
+    When ProcessPoolExecutor forks child processes, they inherit the parent's
+    memory via Copy-on-Write (CoW), so all workers get a fully-warmed cache
+    without making any network requests.
+
+    Core schemas warmed:
+    - STAC Item (v1.0.0)
+    - STAC Collection (v1.0.0)
+    - STAC Catalog (v1.0.0)
+    """
+    try:
+        # Core STAC schema URLs that are commonly used
+        core_schemas = [
+            "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json",
+            "https://schemas.stacspec.org/v1.0.0/collection-spec/v1.0.0/collection.json",
+            "https://schemas.stacspec.org/v1.0.0/catalog-spec/v1.0.0/catalog.json",
+        ]
+
+        from .utilities import fetch_and_parse_schema
+
+        # Fetch and parse each schema to populate the cache
+        for schema_url in core_schemas:
+            try:
+                schema = fetch_and_parse_schema(schema_url)
+                # Convert to JSON string and cache via _build_cached_validator
+                schema_json = json.dumps(schema, sort_keys=True, separators=(",", ":"))
+                _build_cached_validator(schema_json)
+            except Exception:
+                # If a schema fails to load, continue with others
+                # This ensures partial cache warming even if some schemas are unavailable
+                pass
+    except Exception:
+        # If cache warming fails entirely, continue without it
+        # The validators will still work, just without the pre-warmed cache
+        pass
 
 
 def get_optimal_worker_count(max_workers: Optional[int] = None) -> int:
@@ -32,13 +72,13 @@ def get_optimal_worker_count(max_workers: Optional[int] = None) -> int:
         on Linux to detect the actual cores allocated to the container, rather than
         the host machine's total cores.
     """
-    import os
+    import os as os_module
 
     # Try to get container-aware core count on Linux
     try:
-        if hasattr(os, "sched_getaffinity"):
+        if hasattr(os_module, "sched_getaffinity"):
             # Linux: respects Docker/container CPU limits
-            total_cores = len(os.sched_getaffinity(0))
+            total_cores = len(os_module.sched_getaffinity(0))
         else:
             # Fallback for non-Linux systems
             total_cores = multiprocessing.cpu_count()
@@ -109,6 +149,65 @@ def _validate_single_file(file_path: str) -> Tuple[str, bool, List[str]]:
     return file_path, is_valid, errors
 
 
+def _validate_dict(
+    item_dict: Dict[str, Any], source_path: str
+) -> Tuple[str, bool, List[str]]:
+    """
+    Worker function that validates a STAC item dictionary directly (no temp files).
+
+    This function receives pickled dictionaries from the main process, avoiding
+    expensive disk I/O. Each worker process has its own isolated schema cache.
+
+    Args:
+        item_dict: Dictionary representation of a STAC item to validate.
+        source_path: Display path for result reporting (e.g., "file.json[0]").
+
+    Returns:
+        Tuple of (source_path, is_valid, list_of_errors)
+    """
+    errors = []
+
+    try:
+        # Validate the dictionary directly without writing to disk
+        # StacValidate can accept a dict via validate_dict() method
+        validator = StacValidate()
+        validator.stac_content = item_dict
+
+        # Set STAC version from item
+        validator.version = item_dict.get("stac_version", "1.0.0")
+
+        # Run validation on the dictionary
+        validator.validate_dict(item_dict)
+
+        # Collect errors from validation
+        if validator.message:
+            try:
+                messages = validator.message
+                if isinstance(messages, list) and len(messages) > 0:
+                    msg_obj = messages[0]
+                    if not msg_obj.get("valid_stac", False):
+                        # Try multiple error field names
+                        if "errors" in msg_obj:
+                            errors.extend(msg_obj["errors"])
+                        elif "error_message" in msg_obj:
+                            errors.append(msg_obj["error_message"])
+                        else:
+                            errors.append(
+                                f"{msg_obj.get('error_type', 'ValidationError')}"
+                            )
+            except (KeyError, IndexError, TypeError):
+                # If we can't parse, just use the raw message
+                if validator.message:
+                    errors.append(str(validator.message))
+
+    except Exception as e:
+        # Catch any exception during validation
+        return source_path, False, [f"Critical error processing item: {str(e)}"]
+
+    is_valid = len(errors) == 0
+    return source_path, is_valid, errors
+
+
 def validate_concurrently(
     file_paths: List[str],
     max_workers: Optional[int] = None,
@@ -119,8 +218,8 @@ def validate_concurrently(
     Validates a list of STAC files concurrently using available CPU cores.
 
     Uses ProcessPoolExecutor to bypass Python's GIL by creating separate Python
-    processes for each worker. Each core gets its own schema cache, which is
-    warmed up on the first file and then reused for subsequent files.
+    processes for each worker. Pre-warms the schema cache in the main process
+    before forking, so all workers inherit a fully-populated cache via Copy-on-Write.
 
     Args:
         file_paths: List of paths to STAC JSON files or FeatureCollections.
@@ -134,6 +233,10 @@ def validate_concurrently(
     Returns:
         List of result dictionaries with keys: path, valid_stac, errors
     """
+    # Pre-warm the schema cache in the main process before forking workers
+    # This leverages Copy-on-Write so all workers inherit the warmed cache
+    _warm_schema_cache()
+
     # If feature_collection mode, extract features and delegate to validate_dicts
     # for memory-safe chunked processing
     if feature_collection:
@@ -258,14 +361,15 @@ def validate_dicts(
     items: Iterable[Dict[str, Any]],
     max_workers: Optional[int] = None,
     show_progress: bool = True,
-    chunk_size: int = 1000,
+    chunk_size: int = 2000,
 ) -> List[Dict[str, Any]]:
     """
     Validate an iterable of STAC item dictionaries concurrently.
 
-    Internally writes dictionaries to temporary files in bounded chunks for
-    concurrent validation, preventing both out-of-memory (OOM) errors and
-    disk/inode exhaustion in containerized environments.
+    Passes dictionaries directly to worker processes via pickle (memory-based),
+    avoiding expensive disk I/O. Pre-warms the schema cache in the main process
+    before forking, so all workers inherit a fully-populated cache via Copy-on-Write.
+    Processes items in bounded chunks to prevent out-of-memory errors.
 
     Args:
         items: Iterable of STAC item dictionaries to validate
@@ -274,72 +378,112 @@ def validate_dicts(
             - Positive int: Use that many cores (capped at available)
             - Negative int: Use all cores minus that many
         show_progress: Whether to show progress bar (default: True)
-        chunk_size: Number of items to process at a time to bound disk and memory usage.
+        chunk_size: Number of items to process at a time to bound memory usage.
 
     Returns:
         List of validation results with path, valid_stac, and errors (if any)
     """
+    # Pre-warm the schema cache in the main process before forking workers
+    # This leverages Copy-on-Write so all workers inherit the warmed cache
+    _warm_schema_cache()
+
     all_results = []
 
-    # Process items in bounded chunks to protect memory and /tmp disk space
+    try:
+        from tqdm import tqdm
+
+        has_tqdm = True
+    except ImportError:
+        has_tqdm = False
+        show_progress = False
+
+    optimal_workers = get_optimal_worker_count(max_workers)
+
+    # Process items in bounded chunks to protect memory
     for chunk in _chunked_iterable(items, chunk_size):
-        temp_files = []
-        temp_file_to_source = (
-            {}
-        )  # Map temp file paths to source info for result display
+        chunk_list = list(chunk)
+        if not chunk_list:
+            continue
+
         try:
-            # Write this specific chunk to temporary files
-            for item in chunk:
-                # Extract source metadata if present (from validate_concurrently)
-                # Use .get() to avoid mutating the input dictionary
-                source_file = item.get("__source_file__")
-                feature_index = item.get("__feature_index__")
+            with concurrent.futures.ProcessPoolExecutor(
+                max_workers=optimal_workers
+            ) as executor:
+                # Submit all items in chunk to the pool
+                # Pass dictionaries directly via pickle (no temp files)
+                future_to_item = {}
+                for idx, item in enumerate(chunk_list):
+                    # Extract source metadata if present
+                    source_file = item.get("__source_file__")
+                    feature_index = item.get("__feature_index__")
 
-                # Create a payload without internal metadata keys to avoid mutating input
-                payload = {
-                    k: v
-                    for k, v in item.items()
-                    if k not in ("__source_file__", "__feature_index__")
-                }
-
-                with tempfile.NamedTemporaryFile(
-                    mode="w", suffix=".json", delete=False
-                ) as f:
-                    json.dump(payload, f)
-                    tmp_path = f.name
-                    temp_files.append(tmp_path)
-
-                    # Store source info for result mapping
+                    # Create display path for results
                     if source_file is not None:
                         display_path = (
                             f"{source_file}[{feature_index}]"
                             if feature_index is not None
                             else source_file
                         )
-                        temp_file_to_source[tmp_path] = display_path
+                    else:
+                        display_path = f"item-{idx}"
 
-            # Validate the chunk concurrently
-            chunk_results = validate_concurrently(
-                temp_files,
-                max_workers=max_workers,
-                show_progress=show_progress,
-                feature_collection=False,  # Already expanded, no need to re-process
-            )
+                    # Create payload without internal metadata keys
+                    payload = {
+                        k: v
+                        for k, v in item.items()
+                        if k not in ("__source_file__", "__feature_index__")
+                    }
 
-            # Map results back to original source paths if available
-            for result in chunk_results:
-                result_path = result["path"]
-                if result_path in temp_file_to_source:
-                    result["path"] = temp_file_to_source[result_path]
+                    # Submit to worker - dictionary is pickled automatically
+                    future = executor.submit(_validate_dict, payload, display_path)
+                    future_to_item[future] = (display_path, idx)
 
-            all_results.extend(chunk_results)
+                # Wrap iterator with tqdm for progress bar
+                iterator = concurrent.futures.as_completed(future_to_item)
+                if show_progress and has_tqdm:
+                    iterator = tqdm(  # type: ignore
+                        iterator,
+                        total=len(chunk_list),
+                        desc="Validating Items",
+                        unit="item",
+                    )
 
-        finally:
-            # Strictly clean up temporary files before moving to the next chunk
-            for temp_file in temp_files:
-                try:
-                    os.unlink(temp_file)
-                except OSError:
-                    pass
+                # Collect results as they finish
+                for future in iterator:
+                    display_path, idx = future_to_item[future]
+                    source_path, is_valid, errors = future.result()
+
+                    result = {
+                        "path": source_path,
+                        "valid_stac": is_valid,
+                    }
+
+                    if errors:
+                        result["errors"] = errors
+
+                    all_results.append(result)
+
+        except Exception as e:
+            # If chunk processing fails, record error for all items in chunk
+            for idx, item in enumerate(chunk_list):
+                source_file = item.get("__source_file__")
+                feature_index = item.get("__feature_index__")
+
+                if source_file is not None:
+                    display_path = (
+                        f"{source_file}[{feature_index}]"
+                        if feature_index is not None
+                        else source_file
+                    )
+                else:
+                    display_path = f"item-{idx}"
+
+                all_results.append(
+                    {
+                        "path": display_path,
+                        "valid_stac": False,
+                        "errors": [f"Chunk processing error: {str(e)}"],
+                    }
+                )
 
     return all_results

--- a/stac_validator/batch_validator.py
+++ b/stac_validator/batch_validator.py
@@ -213,6 +213,7 @@ def validate_concurrently(
     max_workers: Optional[int] = None,
     show_progress: bool = True,
     feature_collection: bool = False,
+    batch_size: int = 2000,
 ) -> List[Dict[str, Any]]:
     """
     Validates a list of STAC files concurrently using available CPU cores.
@@ -229,6 +230,7 @@ def validate_concurrently(
             - Negative int: Use all cores minus that many (e.g., -1 = all cores - 1)
         show_progress: Whether to display a progress bar (requires tqdm).
         feature_collection: If True, treat files as FeatureCollections and validate each feature.
+        batch_size: Number of items to process at a time to bound memory usage (default: 2000).
 
     Returns:
         List of result dictionaries with keys: path, valid_stac, errors
@@ -286,6 +288,7 @@ def validate_concurrently(
             item_iter(),
             max_workers=max_workers,
             show_progress=show_progress,
+            chunk_size=batch_size,
         )
 
         # Combine error results with validation results

--- a/stac_validator/local_schemas/extensions/eo-v1.0.0.json
+++ b/stac_validator/local_schemas/extensions/eo-v1.0.0.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://stac-extensions.github.io/eo/v1.0.0/schema.json#",
+  "title": "EO Extension",
+  "description": "STAC EO Extension for STAC Items.",
+  "oneOf": [
+    {
+      "$comment": "This is the schema for STAC Items.",
+      "allOf": [
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "properties",
+            "assets"
+          ],
+          "properties": {
+            "type": {
+              "const": "Feature"
+            },
+            "properties": {
+              "$ref": "#/definitions/fields"
+            },
+            "assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/fields"
+              }
+            }
+          },
+          "$comment": "The if-then-else below checks whether the eo:bands is given in assets or not. If yes, allows eo:bands in properties (else), otherwise, disallows eo:bands in properties (then).",
+          "if": {
+            "required": [
+              "assets"
+            ],
+            "properties": {
+              "assets": {
+                "type": "object",
+                "additionalProperties": {
+                  "properties": {
+                    "eo:bands": false
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "properties": {
+                "properties": {
+                  "eo:bands": false
+                }
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "properties": {
+                "properties": {
+                  "eo:bands": {
+                    "$ref": "#/definitions/bands"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        }
+      ]
+    },
+    {
+      "$comment": "This is the schema for STAC Collections.",
+      "allOf": [
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "Collection"
+            },
+            "assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/fields"
+              }
+            },
+            "item_assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/fields"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "stac_extensions": {
+      "type": "object",
+      "required": [
+        "stac_extensions"
+      ],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+          }
+        }
+      }
+    },
+    "fields": {
+      "type": "object",
+      "properties": {
+        "eo:cloud_cover": {
+          "title": "Cloud Cover",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "eo:bands": {
+          "$ref": "#/definitions/bands"
+        }
+      },
+      "patternProperties": {
+        "^(?!eo:)": {}
+      },
+      "additionalProperties": false
+    },
+    "bands": {
+      "title": "Bands",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "title": "Band",
+        "type": "object",
+        "minProperties": 1,
+        "properties": {
+          "name": {
+            "title": "Name of the band",
+            "type": "string"
+          },
+          "common_name": {
+            "title": "Common Name of the band",
+            "type": "string",
+            "enum": [
+              "coastal",
+              "blue",
+              "green",
+              "red",
+              "rededge",
+              "yellow",
+              "pan",
+              "nir",
+              "nir08",
+              "nir09",
+              "cirrus",
+              "swir16",
+              "swir22",
+              "lwir",
+              "lwir11",
+              "lwir12"
+            ]
+          },
+          "center_wavelength": {
+            "title": "Center Wavelength",
+            "type": "number"
+          },
+          "full_width_half_max": {
+            "title": "Full Width Half Max (FWHM)",
+            "type": "number"
+          }
+        }
+      }
+    }
+  }
+}

--- a/stac_validator/local_schemas/extensions/projection-v1.0.0.json
+++ b/stac_validator/local_schemas/extensions/projection-v1.0.0.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+  "title": "Projection Extension",
+  "description": "STAC Projection Extension for STAC Items.",
+  "oneOf": [
+    {
+      "$comment": "This is the schema for STAC Items.",
+      "allOf": [
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "properties",
+            "assets"
+          ],
+          "properties": {
+            "type": {
+              "const": "Feature"
+            },
+            "properties": {
+              "allOf": [
+                {
+                  "$comment": "Require fields here for item properties.",
+                  "required": [
+                    "proj:epsg"
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/fields"
+                }
+              ]
+            },
+            "assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/fields"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        }
+      ]
+    },
+    {
+      "$comment": "This is the schema for STAC Collections.",
+      "allOf": [
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "Collection"
+            },
+            "assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/fields"
+              }
+            },
+            "item_assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/fields"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "stac_extensions": {
+      "type": "object",
+      "required": [
+        "stac_extensions"
+      ],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+          }
+        }
+      }
+    },
+    "fields": {
+      "$comment": "Add your new fields here. Don't require them here, do that above in the item schema.",
+      "type": "object",
+      "properties": {
+        "proj:epsg":{
+          "title":"EPSG code",
+          "type":[
+            "integer",
+            "null"
+          ]
+        },
+        "proj:wkt2":{
+          "title":"Coordinate Reference System in WKT2 format",
+          "type":[
+            "string",
+            "null"
+          ]
+        },
+        "proj:projjson": {
+          "title":"Coordinate Reference System in PROJJSON format",
+          "oneOf": [
+            {
+              "$ref": "https://proj.org/schemas/v0.2/projjson.schema.json"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "proj:geometry":{
+          "$ref": "https://geojson.org/schema/Geometry.json"
+        },
+        "proj:bbox":{
+          "title":"Extent",
+          "type":"array",
+          "oneOf": [
+            {
+              "minItems":4,
+              "maxItems":4
+            },
+            {
+              "minItems":6,
+              "maxItems":6
+            }
+          ],
+          "items":{
+            "type":"number"
+          }
+        },
+        "proj:centroid":{
+          "title":"Centroid",
+          "type":"object",
+          "required": [
+            "lat",
+            "lon"
+          ],
+          "properties": {
+            "lat": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            },
+            "lon": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          }
+        },
+        "proj:shape":{
+          "title":"Shape",
+          "type":"array",
+          "minItems":2,
+          "maxItems":2,
+          "items":{
+            "type":"integer"
+          }
+        },
+        "proj:transform":{
+          "title":"Transform",
+          "type":"array",
+          "oneOf": [
+            {
+              "minItems":6,
+              "maxItems":6
+            },
+            {
+              "minItems":9,
+              "maxItems":9
+            }
+          ],
+          "items":{
+            "type":"number"
+          }
+        }
+      },
+      "patternProperties": {
+        "^(?!proj:)": {}
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/stac_validator/local_schemas/extensions/view-v1.0.0.json
+++ b/stac_validator/local_schemas/extensions/view-v1.0.0.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://stac-extensions.github.io/view/v1.0.0/schema.json#",
+  "title": "View Geometry Extension",
+  "description": "STAC View Geometry Extension for STAC Items and STAC Collections.",
+  "oneOf": [
+    {
+      "$comment": "This is the schema for STAC Items.",
+      "allOf": [
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "properties",
+            "assets"
+          ],
+          "properties": {
+            "type": {
+              "const": "Feature"
+            },
+            "properties": {
+              "allOf": [
+                {
+                  "anyOf": [
+                    {"required": ["view:off_nadir"]},
+                    {"required": ["view:incidence_angle"]},
+                    {"required": ["view:azimuth"]},
+                    {"required": ["view:sun_azimuth"]},
+                    {"required": ["view:sun_elevation"]}
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/fields"
+                }
+              ]
+            },
+            "assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/fields"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        }
+      ]
+    },
+    {
+      "$comment": "This is the schema for STAC Collections.",
+      "allOf": [
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "Collection"
+            },
+            "assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/fields"
+              }
+            },
+            "item_assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/fields"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "stac_extensions": {
+      "type": "object",
+      "required": [
+        "stac_extensions"
+      ],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "contains": {
+              "const": "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+            }
+          }
+        }
+      }
+    },
+    "fields": {
+      "$comment": "Add your new fields here. Don't require them here, do that above in the item schema.",
+      "type": "object",
+      "properties": {
+        "view:off_nadir": {
+          "title": "Off Nadir",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 90
+        },
+        "view:incidence_angle": {
+          "title": "Center incidence angle",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 90
+        },
+        "view:azimuth": {
+          "title": "Azimuth angle",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 360
+        },
+        "view:sun_azimuth": {
+          "title": "Sun Azimuth",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 360
+        },
+        "view:sun_elevation": {
+          "title": "Sun Elevation",
+          "type": "number",
+          "minimum": -90,
+          "maximum": 90
+        }
+      },
+      "patternProperties": {
+        "^(?!view:)": {}
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/stac_validator/local_schemas/v1.0.0/catalog.json
+++ b/stac_validator/local_schemas/v1.0.0/catalog.json
@@ -1,0 +1,94 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schemas.stacspec.org/v1.0.0/catalog-spec/json-schema/catalog.json#",
+    "title": "STAC Catalog Specification",
+    "description": "This object represents Catalogs in a SpatioTemporal Asset Catalog.",
+    "allOf": [
+      {
+        "$ref": "#/definitions/catalog"
+      }
+    ],
+    "definitions": {
+      "catalog": {
+        "title": "STAC Catalog",
+        "type": "object",
+        "required": [
+          "stac_version",
+          "type",
+          "id",
+          "description",
+          "links"
+        ],
+        "properties": {
+          "stac_version": {
+            "title": "STAC version",
+            "type": "string",
+            "const": "1.0.0"
+          },
+          "stac_extensions": {
+            "title": "STAC extensions",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "title": "Reference to a JSON Schema",
+              "type": "string",
+              "format": "iri"
+            }
+          },
+          "type": {
+            "title": "Type of STAC entity",
+            "const": "Catalog"
+          },
+          "id": {
+            "title": "Identifier",
+            "type": "string",
+            "minLength": 1
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "minLength": 1
+          },
+          "links": {
+            "title": "Links",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/link"
+            }
+          }
+        }
+      },
+      "link": {
+        "type": "object",
+        "required": [
+          "rel",
+          "href"
+        ],
+        "properties": {
+          "href": {
+            "title": "Link reference",
+            "type": "string",
+            "format": "iri-reference",
+            "minLength": 1
+          },
+          "rel": {
+            "title": "Link relation type",
+            "type": "string",
+            "minLength": 1
+          },
+          "type": {
+            "title": "Link type",
+            "type": "string"
+          },
+          "title": {
+            "title": "Link title",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }

--- a/stac_validator/local_schemas/v1.0.0/collection.json
+++ b/stac_validator/local_schemas/v1.0.0/collection.json
@@ -1,0 +1,270 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json#",
+    "title": "STAC Collection Specification",
+    "description": "This object represents Collections in a SpatioTemporal Asset Catalog.",
+    "allOf": [
+      {
+        "$ref": "#/definitions/collection"
+      }
+    ],
+    "definitions": {
+      "collection": {
+        "title": "STAC Collection",
+        "description": "These are the fields specific to a STAC Collection. All other fields are inherited from STAC Catalog.",
+        "type": "object",
+        "required": [
+          "stac_version",
+          "type",
+          "id",
+          "description",
+          "license",
+          "extent",
+          "links"
+        ],
+        "properties": {
+          "stac_version": {
+            "title": "STAC version",
+            "type": "string",
+            "const": "1.0.0"
+          },
+          "stac_extensions": {
+            "title": "STAC extensions",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "title": "Reference to a JSON Schema",
+              "type": "string",
+              "format": "iri"
+            }
+          },
+          "type": {
+            "title": "Type of STAC entity",
+            "const": "Collection"
+          },
+          "id": {
+            "title": "Identifier",
+            "type": "string",
+            "minLength": 1
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "minLength": 1
+          },
+          "keywords": {
+            "title": "Keywords",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "license": {
+            "title": "Collection License Name",
+            "type": "string",
+            "pattern": "^[\\w\\-\\.\\+]+$"
+          },
+          "providers": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "name": {
+                  "title": "Organization name",
+                  "type": "string"
+                },
+                "description": {
+                  "title": "Organization description",
+                  "type": "string"
+                },
+                "roles": {
+                  "title": "Organization roles",
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "producer",
+                      "licensor",
+                      "processor",
+                      "host"
+                    ]
+                  }
+                },
+                "url": {
+                  "title": "Organization homepage",
+                  "type": "string",
+                  "format": "iri"
+                }
+              }
+            }
+          },
+          "extent": {
+            "title": "Extents",
+            "type": "object",
+            "required": [
+              "spatial",
+              "temporal"
+            ],
+            "properties": {
+              "spatial": {
+                "title": "Spatial extent object",
+                "type": "object",
+                "required": [
+                  "bbox"
+                ],
+                "properties": {
+                  "bbox": {
+                    "title": "Spatial extents",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "title": "Spatial extent",
+                      "type": "array",
+                      "oneOf": [
+                        {
+                          "minItems":4,
+                          "maxItems":4
+                        },
+                        {
+                          "minItems":6,
+                          "maxItems":6
+                        }
+                      ],
+                      "items": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                }
+              },
+              "temporal": {
+                "title": "Temporal extent object",
+                "type": "object",
+                "required": [
+                  "interval"
+                ],
+                "properties": {
+                  "interval": {
+                    "title": "Temporal extents",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "title": "Temporal extent",
+                      "type": "array",
+                      "minItems": 2,
+                      "maxItems": 2,
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "format": "date-time",
+                        "pattern": "(\\+00:00|Z)$"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "assets": {
+            "$ref": "../../item-spec/json-schema/item.json#/definitions/assets"
+          },
+          "links": {
+            "title": "Links",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/link"
+            }
+          },
+          "summaries": {
+            "$ref": "#/definitions/summaries"
+          }
+        }
+      },
+      "link": {
+        "type": "object",
+        "required": [
+          "rel",
+          "href"
+        ],
+        "properties": {
+          "href": {
+            "title": "Link reference",
+            "type": "string",
+            "format": "iri-reference",
+            "minLength": 1
+          },
+          "rel": {
+            "title": "Link relation type",
+            "type": "string",
+            "minLength": 1
+          },
+          "type": {
+            "title": "Link type",
+            "type": "string"
+          },
+          "title": {
+            "title": "Link title",
+            "type": "string"
+          }
+        }
+      },
+      "summaries": {
+        "type": "object",
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "title": "JSON Schema",
+              "type": "object",
+              "minProperties": 1,
+              "allOf": [
+                {
+                  "$ref": "http://json-schema.org/draft-07/schema"
+                }
+              ]
+            },
+            {
+              "title": "Range",
+              "type": "object",
+              "required": [
+                "minimum",
+                "maximum"
+              ],
+              "properties": {
+                "minimum": {
+                  "title": "Minimum value",
+                  "type": [
+                    "number",
+                    "string"
+                  ]
+                },
+                "maximum": {
+                  "title": "Maximum value",
+                  "type": [
+                    "number",
+                    "string"
+                  ]
+                }
+              }
+            },
+            {
+              "title": "Set of values",
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "description": "For each field only the original data type of the property can occur (except for arrays), but we can't validate that in JSON Schema yet. See the sumamry description in the STAC specification for details."
+              }
+            }
+          ]
+        }
+      }
+    }
+  }

--- a/stac_validator/local_schemas/v1.0.0/item.json
+++ b/stac_validator/local_schemas/v1.0.0/item.json
@@ -1,0 +1,272 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#",
+    "title": "STAC Item",
+    "type": "object",
+    "description": "This object represents the metadata for an item in a SpatioTemporal Asset Catalog.",
+    "allOf": [
+      {
+        "$ref": "#/definitions/core"
+      }
+    ],
+    "definitions": {
+      "common_metadata": {
+        "allOf": [
+          {
+            "$ref": "basics.json"
+          },
+          {
+            "$ref": "datetime.json"
+          },
+          {
+            "$ref": "instrument.json"
+          },
+          {
+            "$ref": "licensing.json"
+          },
+          {
+            "$ref": "provider.json"
+          }
+        ]
+      },
+      "core": {
+        "allOf": [
+          {
+            "$ref": "https://geojson.org/schema/Feature.json"
+          },
+          {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": [
+                  "geometry",
+                  "bbox"
+                ],
+                "properties": {
+                  "geometry": {
+                    "$ref": "https://geojson.org/schema/Geometry.json"
+                  },
+                  "bbox": {
+                    "type": "array",
+                    "oneOf": [
+                      {
+                        "minItems": 4,
+                        "maxItems": 4
+                      },
+                      {
+                        "minItems": 6,
+                        "maxItems": 6
+                      }
+                    ],
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "required": [
+                  "geometry"
+                ],
+                "properties": {
+                  "geometry": {
+                    "type": "null"
+                  },
+                  "bbox": {
+                    "not": {}
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "stac_version",
+              "id",
+              "links",
+              "assets",
+              "properties"
+            ],
+            "properties": {
+              "stac_version": {
+                "title": "STAC version",
+                "type": "string",
+                "const": "1.0.0"
+              },
+              "stac_extensions": {
+                "title": "STAC extensions",
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                  "title": "Reference to a JSON Schema",
+                  "type": "string",
+                  "format": "iri"
+                }
+              },
+              "id": {
+                "title": "Provider ID",
+                "description": "Provider item ID",
+                "type": "string",
+                "minLength": 1
+              },
+              "links": {
+                "title": "Item links",
+                "description": "Links to item relations",
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/link"
+                }
+              },
+              "assets": {
+                "$ref": "#/definitions/assets"
+              },
+              "properties": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/common_metadata"
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "required": [
+                          "datetime"
+                        ],
+                        "properties": {
+                          "datetime": {
+                            "not": {
+                              "type": "null"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "required": [
+                          "datetime",
+                          "start_datetime",
+                          "end_datetime"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "if": {
+              "properties": {
+                "links": {
+                  "contains": {
+                    "required": [
+                      "rel"
+                    ],
+                    "properties": {
+                      "rel": {
+                        "const": "collection"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "then": {
+              "required": [
+                "collection"
+              ],
+              "properties": {
+                "collection": {
+                  "title": "Collection ID",
+                  "description": "The ID of the STAC Collection this Item references to.",
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "else": {
+              "properties": {
+                "collection": {
+                  "not": {}
+                }
+              }
+            }
+          }
+        ]
+      },
+      "link": {
+        "type": "object",
+        "required": [
+          "rel",
+          "href"
+        ],
+        "properties": {
+          "href": {
+            "title": "Link reference",
+            "type": "string",
+            "format": "iri-reference",
+            "minLength": 1
+          },
+          "rel": {
+            "title": "Link relation type",
+            "type": "string",
+            "minLength": 1
+          },
+          "type": {
+            "title": "Link type",
+            "type": "string"
+          },
+          "title": {
+            "title": "Link title",
+            "type": "string"
+          }
+        }
+      },
+      "assets": {
+        "title": "Asset links",
+        "description": "Links to assets",
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/definitions/asset"
+        }
+      },
+      "asset": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "href"
+            ],
+            "properties": {
+              "href": {
+                "title": "Asset reference",
+                "type": "string",
+                "format": "iri-reference",
+                "minLength": 1
+              },
+              "title": {
+                "title": "Asset title",
+                "type": "string"
+              },
+              "description": {
+                "title": "Asset description",
+                "type": "string"
+              },
+              "type": {
+                "title": "Asset type",
+                "type": "string"
+              },
+              "roles": {
+                "title": "Asset roles",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          {
+            "$ref": "#/definitions/common_metadata"
+          }
+        ]
+      }
+    }
+  }

--- a/stac_validator/local_schemas/v1.1.0/catalog.json
+++ b/stac_validator/local_schemas/v1.1.0/catalog.json
@@ -1,0 +1,57 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schemas.stacspec.org/v1.1.0/catalog-spec/json-schema/catalog.json",
+    "title": "STAC Catalog Specification",
+    "description": "This object represents Catalogs in a SpatioTemporal Asset Catalog.",
+    "allOf": [
+      {
+        "$ref": "#/definitions/catalog"
+      },
+      {
+        "$ref": "../../item-spec/json-schema/common.json"
+      }
+    ],
+    "definitions": {
+      "catalog": {
+        "title": "STAC Catalog",
+        "type": "object",
+        "$comment": "title and description is validated through the common metadata.",
+        "required": [
+          "stac_version",
+          "type",
+          "id",
+          "description",
+          "links"
+        ],
+        "properties": {
+          "stac_version": {
+            "title": "STAC version",
+            "type": "string",
+            "const": "1.1.0"
+          },
+          "stac_extensions": {
+            "title": "STAC extensions",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "title": "Reference to a JSON Schema",
+              "type": "string",
+              "format": "iri"
+            }
+          },
+          "type": {
+            "title": "Type of STAC entity",
+            "const": "Catalog"
+          },
+          "id": {
+            "title": "Identifier",
+            "type": "string",
+            "minLength": 1
+          },
+          "links": {
+            "$ref": "../../item-spec/json-schema/item.json#/definitions/links"
+          }
+        }
+      }
+    }
+  }

--- a/stac_validator/local_schemas/v1.1.0/collection.json
+++ b/stac_validator/local_schemas/v1.1.0/collection.json
@@ -1,0 +1,230 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schemas.stacspec.org/v1.1.0/collection-spec/json-schema/collection.json",
+    "title": "STAC Collection Specification",
+    "description": "This object represents Collections in a SpatioTemporal Asset Catalog.",
+    "allOf": [
+      {
+        "$ref": "#/definitions/collection"
+      },
+      {
+        "$ref": "../../item-spec/json-schema/common.json"
+      }
+    ],
+    "definitions": {
+      "collection": {
+        "title": "STAC Collection",
+        "description": "These are the fields specific to a STAC Collection.",
+        "type": "object",
+        "$comment": "title, description, keywords, providers and license is validated through the common metadata.",
+        "required": [
+          "stac_version",
+          "type",
+          "id",
+          "description",
+          "license",
+          "extent",
+          "links"
+        ],
+        "properties": {
+          "stac_version": {
+            "title": "STAC version",
+            "type": "string",
+            "const": "1.1.0"
+          },
+          "stac_extensions": {
+            "title": "STAC extensions",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "title": "Reference to a JSON Schema",
+              "type": "string",
+              "format": "iri"
+            }
+          },
+          "type": {
+            "title": "Type of STAC entity",
+            "const": "Collection"
+          },
+          "id": {
+            "title": "Identifier",
+            "type": "string",
+            "minLength": 1
+          },
+          "extent": {
+            "title": "Extents",
+            "type": "object",
+            "required": [
+              "spatial",
+              "temporal"
+            ],
+            "properties": {
+              "spatial": {
+                "title": "Spatial extent object",
+                "type": "object",
+                "required": [
+                  "bbox"
+                ],
+                "properties": {
+                  "bbox": {
+                    "title": "Spatial extents",
+                    "type": "array",
+                    "oneOf": [
+                      {
+                        "minItems": 1,
+                        "maxItems": 1
+                      },
+                      {
+                        "minItems": 3
+                      }
+                    ],
+                    "items": {
+                      "title": "Spatial extent",
+                      "type": "array",
+                      "oneOf": [
+                        {
+                          "minItems": 4,
+                          "maxItems": 4
+                        },
+                        {
+                          "minItems": 6,
+                          "maxItems": 6
+                        }
+                      ],
+                      "items": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                }
+              },
+              "temporal": {
+                "title": "Temporal extent object",
+                "type": "object",
+                "required": [
+                  "interval"
+                ],
+                "properties": {
+                  "interval": {
+                    "title": "Temporal extents",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "title": "Temporal extent",
+                      "type": "array",
+                      "minItems": 2,
+                      "maxItems": 2,
+                      "items": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "format": "date-time",
+                        "pattern": "(\\+00:00|Z)$"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "assets": {
+            "$ref": "../../item-spec/json-schema/item.json#/definitions/assets"
+          },
+          "item_assets": {
+            "additionalProperties": {
+              "allOf": [
+                {
+                  "type": "object",
+                  "minProperties": 2,
+                  "properties": {
+                    "href": {
+                      "title": "Disallow href",
+                      "not": {}
+                    },
+                    "title": {
+                      "title": "Asset title",
+                      "type": "string"
+                    },
+                    "description": {
+                      "title": "Asset description",
+                      "type": "string"
+                    },
+                    "type": {
+                      "title": "Asset type",
+                      "type": "string"
+                    },
+                    "roles": {
+                      "title": "Asset roles",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                {
+                  "$ref": "../../item-spec/json-schema/common.json"
+                }
+              ]
+            }
+          },
+          "links": {
+            "$ref": "../../item-spec/json-schema/item.json#/definitions/links"
+          },
+          "summaries": {
+            "$ref": "#/definitions/summaries"
+          }
+        }
+      },
+      "summaries": {
+        "type": "object",
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "title": "JSON Schema",
+              "type": "object",
+              "minProperties": 1,
+              "allOf": [
+                {
+                  "$ref": "http://json-schema.org/draft-07/schema"
+                }
+              ]
+            },
+            {
+              "title": "Range",
+              "type": "object",
+              "required": [
+                "minimum",
+                "maximum"
+              ],
+              "properties": {
+                "minimum": {
+                  "title": "Minimum value",
+                  "type": [
+                    "number",
+                    "string"
+                  ]
+                },
+                "maximum": {
+                  "title": "Maximum value",
+                  "type": [
+                    "number",
+                    "string"
+                  ]
+                }
+              }
+            },
+            {
+              "title": "Set of values",
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "description": "For each field only the original data type of the property can occur (except for arrays), but we can't validate that in JSON Schema yet. See the sumamry description in the STAC specification for details."
+              }
+            }
+          ]
+        }
+      }
+    }
+  }

--- a/stac_validator/local_schemas/v1.1.0/item.json
+++ b/stac_validator/local_schemas/v1.1.0/item.json
@@ -1,0 +1,347 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://schemas.stacspec.org/v1.1.0/item-spec/json-schema/item.json",
+    "title": "STAC Item",
+    "type": "object",
+    "description": "This object represents the metadata for an item in a SpatioTemporal Asset Catalog.",
+    "allOf": [
+      {
+        "$ref": "#/definitions/core"
+      }
+    ],
+    "definitions": {
+      "core": {
+        "allOf": [
+          {
+            "$ref": "https://geojson.org/schema/Feature.json"
+          },
+          {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": [
+                  "geometry",
+                  "bbox"
+                ],
+                "properties": {
+                  "geometry": {
+                    "$ref": "https://geojson.org/schema/Geometry.json"
+                  },
+                  "bbox": {
+                    "type": "array",
+                    "oneOf": [
+                      {
+                        "minItems": 4,
+                        "maxItems": 4
+                      },
+                      {
+                        "minItems": 6,
+                        "maxItems": 6
+                      }
+                    ],
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "required": [
+                  "geometry"
+                ],
+                "properties": {
+                  "geometry": {
+                    "type": "null"
+                  },
+                  "bbox": {
+                    "not": {}
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "stac_version",
+              "id",
+              "links",
+              "assets",
+              "properties"
+            ],
+            "properties": {
+              "stac_version": {
+                "title": "STAC version",
+                "type": "string",
+                "const": "1.1.0"
+              },
+              "stac_extensions": {
+                "title": "STAC extensions",
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                  "title": "Reference to a JSON Schema",
+                  "type": "string",
+                  "format": "iri"
+                }
+              },
+              "id": {
+                "title": "Provider ID",
+                "description": "Provider item ID",
+                "type": "string",
+                "minLength": 1
+              },
+              "links": {
+                "$ref": "#/definitions/links"
+              },
+              "assets": {
+                "$ref": "#/definitions/assets"
+              },
+              "properties": {
+                "allOf": [
+                  {
+                    "$ref": "common.json"
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "required": [
+                          "datetime"
+                        ],
+                        "properties": {
+                          "datetime": {
+                            "not": {
+                              "type": "null"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "required": [
+                          "datetime",
+                          "start_datetime",
+                          "end_datetime"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "$comment": "Rules enforcement for STAC Item",
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "links": {
+                      "contains": {
+                        "required": [
+                          "rel"
+                        ],
+                        "properties": {
+                          "rel": {
+                            "const": "collection"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "then": {
+                  "required": [
+                    "collection"
+                  ],
+                  "properties": {
+                    "collection": {
+                      "title": "Collection ID",
+                      "description": "The ID of the STAC Collection this Item references to.",
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                },
+                "else": {
+                  "properties": {
+                    "collection": {
+                      "not": {}
+                    }
+                  }
+                }
+              },
+              {
+                "$comment": "The if-then-else below checks whether the bands field is given in assets or not. If not, allows bands in properties (then), otherwise, disallows bands in properties (else).",
+                "if": {
+                  "$comment": "If there is no asset with bands...",
+                  "required": [
+                    "assets"
+                  ],
+                  "properties": {
+                    "assets": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "properties": {
+                          "bands": false
+                        }
+                      }
+                    }
+                  }
+                },
+                "then": {
+                  "$comment": "... then bands are not allowed in properties...",
+                  "properties": {
+                    "properties": {
+                      "properties": {
+                        "bands": false
+                      }
+                    }
+                  }
+                },
+                "else": {
+                  "$comment": "... otherwise bands are allowed in properties.",
+                  "properties": {
+                    "properties": {
+                      "$ref": "bands.json"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "links": {
+        "title": "Item links",
+        "description": "Links to item relations",
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/link"
+        }
+      },
+      "link": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "rel",
+              "href"
+            ],
+            "properties": {
+              "href": {
+                "title": "Link reference",
+                "type": "string",
+                "format": "iri-reference",
+                "minLength": 1
+              },
+              "rel": {
+                "title": "Link relation type",
+                "type": "string",
+                "minLength": 1
+              },
+              "type": {
+                "title": "Link type",
+                "type": "string"
+              },
+              "title": {
+                "title": "Link title",
+                "type": "string"
+              },
+              "method": {
+                "title": "Link method",
+                "type": "string",
+                "pattern": "^[A-Z]+$",
+                "default": "GET"
+              },
+              "headers": {
+                "title": "Link headers",
+                "type": "object",
+                "additionalProperties": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ]
+                }
+              },
+              "body": {
+                "title": "Link body",
+                "$comment": "Any type is allowed."
+              }
+            },
+            "$comment": "Link with relationship `self` must be absolute URI",
+            "if": {
+              "properties": {
+                "rel": {
+                  "const": "self"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "href": {
+                  "format": "iri"
+                }
+              }
+            }
+          },
+          {
+            "$ref": "common.json"
+          }
+        ]
+      },
+      "assets": {
+        "title": "Asset links",
+        "description": "Links to assets",
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/definitions/asset"
+        }
+      },
+      "asset": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "href"
+            ],
+            "properties": {
+              "href": {
+                "title": "Asset reference",
+                "type": "string",
+                "format": "iri-reference",
+                "minLength": 1
+              },
+              "title": {
+                "title": "Asset title",
+                "type": "string"
+              },
+              "description": {
+                "title": "Asset description",
+                "type": "string"
+              },
+              "type": {
+                "title": "Asset type",
+                "type": "string"
+              },
+              "roles": {
+                "title": "Asset roles",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          {
+            "$ref": "common.json"
+          }
+        ]
+      }
+    }
+  }

--- a/stac_validator/stac_validator.py
+++ b/stac_validator/stac_validator.py
@@ -359,9 +359,9 @@ def main(
     help="Do not print output to console.",
 )
 @click.option(
-    "--feature-collection",
+    "--item-collection",
     is_flag=True,
-    help="Treat files as GeoJSON FeatureCollections and validate each feature individually.",
+    help="Treat files as ItemCollections and validate each item individually.",
 )
 @click.option(
     "--verbose",
@@ -376,7 +376,7 @@ def main(
 )
 @click.option(
     "--batch-size",
-    type=int,
+    type=click.IntRange(min=1),
     default=2000,
     help="Batch size for chunked processing. Larger batches use more memory but may be faster. Defaults to 2000.",
 )
@@ -385,7 +385,7 @@ def batch(
     cores: Optional[int],
     no_progress: bool,
     no_output: bool,
-    feature_collection: bool,
+    item_collection: bool,
     verbose: bool,
     schema_cache_size: int,
     batch_size: int,
@@ -433,7 +433,7 @@ def batch(
             list(files),
             max_workers=cores,
             show_progress=not no_progress,
-            feature_collection=feature_collection,
+            feature_collection=item_collection,
             batch_size=batch_size,
         )
 
@@ -454,9 +454,11 @@ def batch(
                 if not result.get("valid_stac", False):
                     # Try to get item ID from result, fallback to path
                     item_id = result.get("item_id", result.get("path", "unknown"))
+                    
+                    # Handle both old format (errors array) and new format (error_message/failed_schema)
                     if "errors" in result:
+                        # Old format: errors array with dict entries
                         for error in result["errors"]:
-                            # Handle both dict and string error formats
                             if isinstance(error, dict):
                                 error_msg = error.get("message", str(error))
                                 error_schema = error.get("schema", "")
@@ -464,6 +466,12 @@ def batch(
                             else:
                                 error_key = (str(error), "")
                             error_groups[error_key].append(item_id)
+                    elif "error_message" in result:
+                        # New format: error_message and failed_schema fields
+                        error_msg = result.get("error_message", "")
+                        error_schema = result.get("failed_schema", "")
+                        error_key = (error_msg, error_schema)
+                        error_groups[error_key].append(item_id)
 
             # Print grouped errors with compact formatting
             for idx, ((error_msg, error_schema), item_ids) in enumerate(

--- a/stac_validator/stac_validator.py
+++ b/stac_validator/stac_validator.py
@@ -454,7 +454,7 @@ def batch(
                 if not result.get("valid_stac", False):
                     # Try to get item ID from result, fallback to path
                     item_id = result.get("item_id", result.get("path", "unknown"))
-                    
+
                     # Handle both old format (errors array) and new format (error_message/failed_schema)
                     if "errors" in result:
                         # Old format: errors array with dict entries

--- a/stac_validator/stac_validator.py
+++ b/stac_validator/stac_validator.py
@@ -374,6 +374,12 @@ def main(
     default=16,
     help="Max number of schema entries to cache per worker process. Defaults to 16.",
 )
+@click.option(
+    "--batch-size",
+    type=int,
+    default=2000,
+    help="Batch size for chunked processing. Larger batches use more memory but may be faster. Defaults to 2000.",
+)
 def batch(
     files: Tuple[str, ...],
     cores: Optional[int],
@@ -382,6 +388,7 @@ def batch(
     feature_collection: bool,
     verbose: bool,
     schema_cache_size: int,
+    batch_size: int,
 ):
     """Validate multiple STAC files concurrently using all available CPU cores.
 
@@ -427,6 +434,7 @@ def batch(
             max_workers=cores,
             show_progress=not no_progress,
             feature_collection=feature_collection,
+            batch_size=batch_size,
         )
 
         # Calculate statistics

--- a/stac_validator/stac_validator.py
+++ b/stac_validator/stac_validator.py
@@ -444,12 +444,51 @@ def batch(
         # Print details of failed validations first (only in non-verbose mode)
         if not no_output and invalid_count > 0 and not verbose:
             click.secho("Failed validations:", fg="red")
+
+            # Group errors by (message, schema) and collect item IDs
+            from collections import defaultdict
+
+            error_groups = defaultdict(list)
+
             for result in results:
                 if not result.get("valid_stac", False):
-                    click.secho(f"  {result['path']}", fg="red")
+                    # Try to get item ID from result, fallback to path
+                    item_id = result.get("item_id", result.get("path", "unknown"))
                     if "errors" in result:
                         for error in result["errors"]:
-                            click.secho(f"    - {error}", fg="yellow")
+                            # Handle both dict and string error formats
+                            if isinstance(error, dict):
+                                error_msg = error.get("message", str(error))
+                                error_schema = error.get("schema", "")
+                                error_key = (error_msg, error_schema)
+                            else:
+                                error_key = (str(error), "")
+                            error_groups[error_key].append(item_id)
+
+            # Print grouped errors with compact formatting
+            for idx, ((error_msg, error_schema), item_ids) in enumerate(
+                sorted(error_groups.items())
+            ):
+                # Add blank line between error sections (but not before the first one)
+                if idx > 0:
+                    click.secho()
+
+                # Format item IDs compactly (max 5 per line)
+                if len(item_ids) <= 5:
+                    ids_str = ", ".join(str(id) for id in item_ids)
+                    click.secho(f"  [{ids_str}]", fg="red")
+                else:
+                    # For many items, show first few and count
+                    first_few = ", ".join(str(id) for id in item_ids[:5])
+                    remaining = len(item_ids) - 5
+                    click.secho(f"  [{first_few}, ... +{remaining} more]", fg="red")
+
+                # Display error message
+                click.secho(f"    - {error_msg}", fg="yellow")
+
+                # Display schema if available
+                if error_schema:
+                    click.secho(f"      Schema: {error_schema}", fg="cyan")
 
         # Print full JSON output in verbose mode
         if not no_output and verbose:

--- a/stac_validator/stac_validator.py
+++ b/stac_validator/stac_validator.py
@@ -192,6 +192,7 @@ def recursive_validation_summary(message: List[Dict[str, Any]]) -> None:
 )
 @click.option(
     "--item-collection",
+    "--feature-collection",
     is_flag=True,
     help="Validate item collection response. Can be combined with --pages. Defaults to one page.",
 )
@@ -360,6 +361,7 @@ def main(
 )
 @click.option(
     "--item-collection",
+    "--feature-collection",
     is_flag=True,
     help="Treat files as ItemCollections and validate each item individually.",
 )

--- a/stac_validator/stac_validator.py
+++ b/stac_validator/stac_validator.py
@@ -304,6 +304,7 @@ def main(
         log=log_file,
         pydantic=pydantic,
         verbose=verbose,
+        show_progress=True,
     )
 
     try:

--- a/stac_validator/utilities.py
+++ b/stac_validator/utilities.py
@@ -193,11 +193,23 @@ def _build_schema_cache(maxsize: int):
     return _cached_fetch
 
 
+def _build_validator_cache(maxsize: int):
+    @functools.lru_cache(maxsize=maxsize)
+    def _cached_validator(schema_json: str) -> Draft202012Validator:
+        schema = json.loads(schema_json)
+        return Draft202012Validator(schema)
+
+    return _cached_validator
+
+
 _schema_cache = _build_schema_cache(DEFAULT_SCHEMA_CACHE_SIZE)
+_validator_cache = _build_validator_cache(DEFAULT_SCHEMA_CACHE_SIZE)
 
 
 def set_schema_cache_size(maxsize: int) -> None:
     """Reconfigure the schema cache max size at runtime.
+
+    Controls both the fetch/parse cache and the compiled validator cache.
 
     Args:
         maxsize: Maximum number of cached schema entries. Use 0 to disable caching.
@@ -208,8 +220,9 @@ def set_schema_cache_size(maxsize: int) -> None:
     if maxsize < 0:
         raise ValueError("schema cache size must be greater than or equal to 0")
 
-    global _schema_cache
+    global _schema_cache, _validator_cache
     _schema_cache = _build_schema_cache(maxsize)
+    _validator_cache = _build_validator_cache(maxsize)
 
 
 def _fetch_and_parse_schema_cache_info():
@@ -417,13 +430,13 @@ def fetch_schema_with_override(
     return fetch_and_parse_schema(schema_path)
 
 
-@functools.lru_cache(maxsize=128)
-def _build_cached_validator(schema_json: str):
+def _build_cached_validator(schema_json: str) -> Draft202012Validator:
     """
     Build and cache a Draft202012Validator from a JSON schema string.
 
-    This function is cached to avoid recompiling the same JSON schema multiple times.
+    This function uses the dynamic validator cache configured via set_schema_cache_size().
     The expensive operation of building the validator's validation tree is cached here.
+    Uses a global lookup to respect runtime cache size changes.
 
     Args:
         schema_json (str): JSON string representation of the schema.
@@ -431,8 +444,8 @@ def _build_cached_validator(schema_json: str):
     Returns:
         Draft202012Validator: Compiled validator object.
     """
-    schema = json.loads(schema_json)
-    return Draft202012Validator(schema)
+    # Use global lookup to respect runtime cache size changes
+    return globals()['_validator_cache'](schema_json)
 
 
 def validate_with_ref_resolver(

--- a/stac_validator/utilities.py
+++ b/stac_validator/utilities.py
@@ -341,24 +341,6 @@ def fetch_schema_with_override(
 
 
 @functools.lru_cache(maxsize=128)
-def _get_cached_schema(schema_path: str, schema_json: str):
-    """
-    Cache parsed schemas to avoid re-parsing the same JSON schema multiple times.
-
-    This function is cached to avoid recompiling the same JSON schema multiple times.
-    The schema_json parameter is a JSON string representation of the schema to make it hashable.
-
-    Args:
-        schema_path (str): Path or URI of the JSON Schema.
-        schema_json (str): JSON string representation of the schema.
-
-    Returns:
-        dict: Parsed schema dictionary.
-    """
-    return json.loads(schema_json)
-
-
-@functools.lru_cache(maxsize=128)
 def _build_cached_validator(schema_json: str):
     """
     Build and cache a Draft202012Validator from a JSON schema string.

--- a/stac_validator/utilities.py
+++ b/stac_validator/utilities.py
@@ -340,6 +340,42 @@ def fetch_schema_with_override(
     return fetch_and_parse_schema(schema_path)
 
 
+@functools.lru_cache(maxsize=128)
+def _get_cached_schema(schema_path: str, schema_json: str):
+    """
+    Cache parsed schemas to avoid re-parsing the same JSON schema multiple times.
+
+    This function is cached to avoid recompiling the same JSON schema multiple times.
+    The schema_json parameter is a JSON string representation of the schema to make it hashable.
+
+    Args:
+        schema_path (str): Path or URI of the JSON Schema.
+        schema_json (str): JSON string representation of the schema.
+
+    Returns:
+        dict: Parsed schema dictionary.
+    """
+    return json.loads(schema_json)
+
+
+@functools.lru_cache(maxsize=128)
+def _build_cached_validator(schema_json: str):
+    """
+    Build and cache a Draft202012Validator from a JSON schema string.
+
+    This function is cached to avoid recompiling the same JSON schema multiple times.
+    The expensive operation of building the validator's validation tree is cached here.
+
+    Args:
+        schema_json (str): JSON string representation of the schema.
+
+    Returns:
+        Draft202012Validator: Compiled validator object.
+    """
+    schema = json.loads(schema_json)
+    return Draft202012Validator(schema)
+
+
 def validate_with_ref_resolver(
     schema_path: str, content: Dict, schema_map: Optional[Dict] = None
 ) -> None:
@@ -367,8 +403,13 @@ def validate_with_ref_resolver(
         uri=schema_path, resource=resource
     )  # type: ignore
 
-    # Validate the content against the schema
-    validator = Draft202012Validator(schema, registry=registry)
+    # Use cached validator with registry for reference resolution
+    # Convert schema to JSON string for caching key
+    schema_json = json.dumps(schema, sort_keys=True, separators=(",", ":"))
+    cached_base_validator = _build_cached_validator(schema_json)
+
+    # Create a new validator with the registry (registry cannot be cached as it's mutable)
+    validator = Draft202012Validator(cached_base_validator.schema, registry=registry)
     validator.validate(content)
 
 

--- a/stac_validator/utilities.py
+++ b/stac_validator/utilities.py
@@ -1,5 +1,6 @@
 import functools
 import json
+import logging
 import os
 import ssl
 from typing import Dict, Optional, Tuple
@@ -169,7 +170,7 @@ def fetch_and_parse_file(input_path: str, headers: Optional[Dict] = None) -> Dic
     """
     try:
         if is_url(input_path):
-            resp = requests.get(input_path, headers=headers)
+            resp = requests.get(input_path, headers=headers, timeout=10)
             resp.raise_for_status()
             data = resp.json()
         else:
@@ -219,6 +220,48 @@ def _fetch_and_parse_schema_cache_clear() -> None:
     _schema_cache.cache_clear()
 
 
+_cached_schemas = set()
+
+
+def _map_extension_url_to_local(url: str) -> str:
+    """
+    Map remote extension schema URLs to local file paths if available.
+
+    For example:
+    - https://stac-extensions.github.io/eo/v1.0.0/schema.json -> local_schemas/extensions/eo-v1.0.0.json
+    - https://stac-extensions.github.io/projection/v1.0.0/schema.json -> local_schemas/extensions/projection-v1.0.0.json
+
+    Args:
+        url: Remote schema URL
+
+    Returns:
+        Local file path if available, otherwise returns the original URL
+    """
+    import os
+    import re
+
+    # Match pattern: https://stac-extensions.github.io/{extension}/{version}/schema.json
+    match = re.match(
+        r"https://stac-extensions\.github\.io/([^/]+)/v([^/]+)/schema\.json", url
+    )
+
+    if match:
+        extension_name = match.group(1)
+        version = match.group(2)
+        local_file = os.path.join(
+            os.path.dirname(__file__),
+            "local_schemas",
+            "extensions",
+            f"{extension_name}-v{version}.json",
+        )
+
+        # Return local path if file exists, otherwise return original URL
+        if os.path.exists(local_file):
+            return local_file
+
+    return url
+
+
 def fetch_and_parse_schema(input_path: str) -> Dict:
     """Fetches and parses a JSON schema file from a URL or local file using a cache.
 
@@ -227,6 +270,8 @@ def fetch_and_parse_schema(input_path: str) -> Dict:
     function uses the requests library to download the file, otherwise it opens the
     local file with the json library. Additionally, this function caches the results of
     previous function calls to reduce the number of times the file is fetched and parsed.
+
+    For extension schemas, attempts to use local files if available to avoid network requests.
 
     Args:
         input_path: A string representing the URL or local file path to the JSON schema file.
@@ -238,7 +283,28 @@ def fetch_and_parse_schema(input_path: str) -> Dict:
         ValueError: If the input is not a valid URL or local file path.
         requests.exceptions.RequestException: If there is an error while downloading the file.
     """
-    return _schema_cache(input_path)
+    logger = logging.getLogger(__name__)
+
+    # Try to map extension URLs to local files
+    resolved_path = _map_extension_url_to_local(input_path)
+
+    # Log when fetching a new schema
+    if resolved_path not in _cached_schemas:
+        if resolved_path != input_path:
+            logger.info(
+                f"Using local schema: {resolved_path} (mapped from {input_path})"
+            )
+        else:
+            logger.info(f"Fetching schema: {input_path}")
+
+    result = _schema_cache(resolved_path)
+
+    # Track which schemas have been cached for logging
+    if resolved_path not in _cached_schemas:
+        _cached_schemas.add(resolved_path)
+        logger.info(f"✓ Cached schema: {resolved_path}")
+
+    return result
 
 
 fetch_and_parse_schema.cache_info = _fetch_and_parse_schema_cache_info  # type: ignore[attr-defined]
@@ -247,15 +313,26 @@ fetch_and_parse_schema.cache_clear = _fetch_and_parse_schema_cache_clear  # type
 
 def set_schema_addr(version: str, stac_type: str) -> str:
     """Set the URL address for the JSON schema to be used for validating the STAC object.
-    Validate new versions at schemas.stacspec.org
+    Uses local schema files for core STAC schemas (v1.0.0 and v1.1.0) to avoid network requests.
+    Falls back to remote URLs for other versions.
 
     Args:
         version (str): The version number of the STAC object.
         stac_type (str): The type of the STAC object (e.g. "item", "collection").
 
     Returns:
-        str: The URL address for the JSON schema.
+        str: The file path or URL address for the JSON schema.
     """
+    # Use local schemas for supported versions to avoid network requests
+    if version in ("1.0.0", "1.1.0"):
+        import os
+
+        schema_dir = os.path.join(os.path.dirname(__file__), "local_schemas", version)
+        schema_file = os.path.join(schema_dir, f"{stac_type}.json")
+        if os.path.exists(schema_file):
+            return schema_file
+
+    # Fall back to remote URLs for unsupported versions
     if version in NEW_VERSIONS:
         return f"https://schemas.stacspec.org/v{version}/{stac_type}-spec/json-schema/{stac_type}.json"
     else:

--- a/stac_validator/utilities.py
+++ b/stac_validator/utilities.py
@@ -445,7 +445,7 @@ def _build_cached_validator(schema_json: str) -> Draft202012Validator:
         Draft202012Validator: Compiled validator object.
     """
     # Use global lookup to respect runtime cache size changes
-    return globals()['_validator_cache'](schema_json)
+    return globals()["_validator_cache"](schema_json)
 
 
 def validate_with_ref_resolver(

--- a/stac_validator/validate.py
+++ b/stac_validator/validate.py
@@ -74,6 +74,7 @@ class StacValidate:
         log: str = "",
         pydantic: bool = False,
         verbose: bool = False,
+        show_progress: bool = False,
     ):
         self.stac_file = stac_file
         self.collections = collections
@@ -100,6 +101,7 @@ class StacValidate:
         self.log = log
         self.pydantic = pydantic
         self.verbose = verbose
+        self.show_progress = show_progress
 
         self._original_schema_paths = {}
         cli_schema_map = schema_map or {}
@@ -788,7 +790,20 @@ class StacValidate:
         # Store the original stac_file to restore it later
         original_stac_file = self.stac_file
 
-        for item in item_collection["features"]:
+        # Use tqdm for progress bar if available and show_progress is True
+        if self.show_progress:
+            try:
+                from tqdm import tqdm
+
+                items_iter = tqdm(
+                    item_collection["features"], desc="Validating Items", unit="item"
+                )
+            except ImportError:
+                items_iter = item_collection["features"]
+        else:
+            items_iter = item_collection["features"]
+
+        for item in items_iter:
             # Update the path to include the item ID for better traceability
             if isinstance(original_stac_file, str) and "id" in item:
                 # Remove any query string from the URL before appending the item ID


### PR DESCRIPTION
- Added benchmark_validation.py script for comparing batch vs legacy validation performance
- Added `--batch-size` option to `batch` command for configurable chunk processing (default: 2000)
- Implemented compiled validator caching using `@functools.lru_cache` to avoid recompiling JSON schemas
- Implemented direct dictionary passing to worker processes via pickle instead of temp file I/O
- Implemented pre-warming of schema cache before forking worker processes via Copy-on-Write