### PR TITLE
Release v4.2.2, remove deprecation warnings, provide message dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,13 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 
 ## [v4.2.2] - 2026-04-29
 
+### Added
+
+- Added message output for fast validator command [#292](https://github.com/stac-utils/stac-validator/pull/292)
+
 ### Removed
 
-- Deprecation warnings for `stac-validator` installation [#291](https://github.com/stac-utils/stac-validator/pull/291)
+- Deprecation warnings for `stac-validator` installation [#292](https://github.com/stac-utils/stac-validator/pull/292)
 
 ## [v4.2.1] - 2026-04-27
 
@@ -440,7 +444,8 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 - With the newest version - 1.0.0-beta.2 - items will run through jsonchema validation before the PySTAC validation. The reason for this is that jsonschema will give more informative error messages. This should be addressed better in the future. This is not the case with the --recursive option as time can be a concern here with larger collections.
 - Logging. Various additions were made here depending on the options selected. This was done to help assist people to update their STAC collections.
 
-[Unreleased]: https://github.com/sparkgeo/stac-validator/compare/v4.2.1..main
+[Unreleased]: https://github.com/sparkgeo/stac-validator/compare/v4.2.2..main
+[v4.2.2]: https://github.com/sparkgeo/stac-validator/compare/v4.2.1..v4.2.2
 [v4.2.1]: https://github.com/sparkgeo/stac-validator/compare/v4.2.0..v4.2.1
 [v4.2.0]: https://github.com/sparkgeo/stac-validator/compare/v4.1.0..v4.2.0
 [v4.1.0]: https://github.com/sparkgeo/stac-validator/compare/v4.0.1..v4.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ The format is (loosely) based on [Keep a Changelog](http://keepachangelog.com/) 
 
 ### Updated
 
+## [v4.2.2] - 2026-04-29
+
+### Removed
+
+- Deprecation warnings for `stac-validator` installation [#291](https://github.com/stac-utils/stac-validator/pull/291)
+
 ## [v4.2.1] - 2026-04-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -811,6 +811,54 @@ stac.validate_item_collection_dict(item_collection_dict)
 print(stac.message)
 ```
 
+**Fast Validation (High-Speed with Local Caching)**
+
+For large FeatureCollections or when you need maximum speed with minimal memory overhead:
+
+```python
+from stac_validator.fast_validator import FastValidator
+import json
+
+# Validate a FeatureCollection or single STAC object
+fv = FastValidator("large_collection.json", quiet=True)
+fv.run()
+
+# Access validation results via the message attribute
+print(json.dumps(fv.message, indent=2))
+
+# Example output:
+# {
+#   "path": "large_collection.json",
+#   "valid_stac": true,
+#   "stac_versions": ["1.0.0", "1.1.0"],
+#   "schemas_checked": [
+#     "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json",
+#     "https://schemas.stacspec.org/v1.1.0/item-spec/json-schema/item.json",
+#     "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+#   ],
+#   "total_objects": 1000,
+#   "valid_objects": 998,
+#   "invalid_objects": 2,
+#   "setup_time_ms": 145.32,
+#   "execution_time_ms": 245.67,
+#   "errors": [
+#     {
+#       "error_message": "STAC Spec Violation: Missing {'rel': 'collection'} in links array.",
+#       "affected_items": ["item_1", "item_2"],
+#       "count": 2
+#     }
+#   ]
+# }
+
+# Check validity
+if fv.valid:
+    print(f"✅ All {fv.message[0]['valid_objects']} items are valid")
+else:
+    print(f"❌ {fv.message[0]['invalid_objects']} items failed validation")
+    for error in fv.message[0]['errors']:
+        print(f"  - {error['error_message']}: {error['count']} items affected")
+```
+
 **Configure Schema Cache Size**
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "stac_valid"
-version = "4.2.1"
+version = "4.2.2"
 description = "A package to validate STAC files"
 authors = [
+    {name = "James Banting"},
     {name = "Jonathan Healy", email = "jon@healy-hyperspatial.dev"}
 ]
 license = {text = "Apache-2.0"}

--- a/stac_validator/__init__.py
+++ b/stac_validator/__init__.py
@@ -1,8 +1,0 @@
-import warnings
-
-warnings.warn(
-    "For v4.2.0+, the PyPI package has moved. "
-    "Please update your requirements to use: pip install stac-valid",
-    DeprecationWarning,
-    stacklevel=2,
-)

--- a/stac_validator/fast_validator.py
+++ b/stac_validator/fast_validator.py
@@ -132,6 +132,7 @@ class FastValidator:
         self.quiet = quiet
         self.valid = True
         self.verbose = verbose
+        self.message: List[Dict[str, Any]] = []
         QUIET_MODE = quiet
 
     def run(self):
@@ -199,6 +200,8 @@ class FastValidator:
         valid_count = 0
         invalid_count = 0
         error_registry: Dict[str, List[str]] = {}
+        stac_versions_found: set = set()
+        schemas_checked: set = set()
 
         for index, item in enumerate(items_to_validate):
             # Determine specific STAC attributes for this object
@@ -206,10 +209,31 @@ class FastValidator:
             stac_version = item.get("stac_version", "1.0.0")
             extensions = item.get("stac_extensions", [])
 
+            # Track versions and schemas
+            stac_versions_found.add(stac_version)
+
             # Map Feature->Item, others keep their type
             actual_type = (
                 "Item" if item.get("type") == "Feature" else item.get("type", "Catalog")
             )
+
+            # Build schema URI for this object type
+            stac_type_lower = actual_type.lower()
+            if stac_type_lower in ["item", "feature"]:
+                base_schema = f"https://schemas.stacspec.org/v{stac_version}/item-spec/json-schema/item.json"
+            elif stac_type_lower == "collection":
+                base_schema = f"https://schemas.stacspec.org/v{stac_version}/collection-spec/json-schema/collection.json"
+            elif stac_type_lower == "catalog":
+                base_schema = f"https://schemas.stacspec.org/v{stac_version}/catalog-spec/json-schema/catalog.json"
+            else:
+                base_schema = ""
+
+            if base_schema:
+                schemas_checked.add(base_schema)
+
+            # Track extensions
+            for ext in extensions:
+                schemas_checked.add(ext)
 
             # --- Setup Timer ---
             t0 = time.perf_counter()
@@ -308,5 +332,28 @@ class FastValidator:
                 if count > 3:
                     sample_ids += f" ... (and {count - 3} more)"
                 click.echo(f"   Examples:       {sample_ids}")
+
+        # Populate the message attribute for API usage (similar to StacValidate)
+        self.message = [
+            {
+                "path": self.stac_file,
+                "valid_stac": self.valid,
+                "stac_versions": sorted(list(stac_versions_found)),
+                "schemas_checked": sorted(list(schemas_checked)),
+                "total_objects": len(items_to_validate),
+                "valid_objects": valid_count,
+                "invalid_objects": invalid_count,
+                "setup_time_ms": total_setup_ms,
+                "execution_time_ms": total_exec_ms,
+                "errors": [
+                    {
+                        "error_message": err_msg,
+                        "affected_items": affected_ids,
+                        "count": len(affected_ids),
+                    }
+                    for err_msg, affected_ids in error_registry.items()
+                ],
+            }
+        ]
 
         click.echo("\n")

--- a/stac_validator/stac_validator.py
+++ b/stac_validator/stac_validator.py
@@ -561,13 +561,7 @@ def cli():
       stac-validator batch <file> --feature-collection [options]
       stac-validator fast <file> [options]
     """
-    if "stac-validator" in sys.argv[0]:
-        click.secho(
-            "⚠️ NOTICE: For v4.2.0+, the PyPI package has moved. "
-            "Please update your environments using: pip install stac-valid\n",
-            fg="yellow",
-            err=True,
-        )
+    pass
 
 
 # Register commands

--- a/stac_validator/stac_validator.py
+++ b/stac_validator/stac_validator.py
@@ -10,14 +10,6 @@ from .fast_validator import FastValidator
 from .utilities import set_schema_cache_size
 from .validate import StacValidate
 
-if sys.argv and "stac-validator" in sys.argv[0]:
-    click.secho(
-        "⚠️ NOTICE: For v4.2.0+, the PyPI package has moved. "
-        "Please update your environments using: pip install stac-valid\n",
-        fg="yellow",
-        err=True,
-    )
-
 
 def _print_summary(
     title: str, valid_count: int, total_count: int, obj_type: str = "STAC objects"

--- a/tests/test_fast_validator.py
+++ b/tests/test_fast_validator.py
@@ -304,3 +304,105 @@ class TestFastValidatorPerformance:
         fv = FastValidator(str(fc_path), quiet=True)
         fv.run()
         assert fv.valid is True
+
+    def test_message_attribute_structure(self, valid_item):
+        """Test that the message attribute has the correct structure."""
+        fv = FastValidator(valid_item, quiet=True)
+        fv.run()
+
+        # Verify message is a list with one dict
+        assert isinstance(fv.message, list)
+        assert len(fv.message) == 1
+
+        msg = fv.message[0]
+
+        # Verify required fields exist
+        assert "path" in msg
+        assert "valid_stac" in msg
+        assert "stac_versions" in msg
+        assert "schemas_checked" in msg
+        assert "total_objects" in msg
+        assert "valid_objects" in msg
+        assert "invalid_objects" in msg
+        assert "setup_time_ms" in msg
+        assert "execution_time_ms" in msg
+        assert "errors" in msg
+
+        # Verify field types
+        assert isinstance(msg["path"], str)
+        assert isinstance(msg["valid_stac"], bool)
+        assert isinstance(msg["stac_versions"], list)
+        assert isinstance(msg["schemas_checked"], list)
+        assert isinstance(msg["total_objects"], int)
+        assert isinstance(msg["valid_objects"], int)
+        assert isinstance(msg["invalid_objects"], int)
+        assert isinstance(msg["setup_time_ms"], float)
+        assert isinstance(msg["execution_time_ms"], float)
+        assert isinstance(msg["errors"], list)
+
+    def test_message_attribute_valid_items(self, valid_feature_collection):
+        """Test message attribute for valid items."""
+        fv = FastValidator(valid_feature_collection, quiet=True)
+        fv.run()
+
+        msg = fv.message[0]
+
+        # For valid items
+        assert msg["valid_stac"] is True
+        assert msg["total_objects"] == 5
+        assert msg["valid_objects"] == 5
+        assert msg["invalid_objects"] == 0
+        assert len(msg["errors"]) == 0
+
+        # Verify versions and schemas are tracked
+        assert len(msg["stac_versions"]) > 0
+        assert len(msg["schemas_checked"]) > 0
+        assert "1.0.0" in msg["stac_versions"]
+
+    def test_message_attribute_invalid_items(self, tmp_path):
+        """Test message attribute for invalid items."""
+        fc_path = tmp_path / "invalid_fc.json"
+        fc_data = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "stac_version": "1.0.0",
+                    "type": "Feature",
+                    "id": "item-1",
+                    "geometry": None,
+                    "properties": {"datetime": "2023-01-01T00:00:00Z"},
+                    "links": [{"rel": "self", "href": "http://example.com"}],
+                    "assets": {},
+                },
+                {
+                    "stac_version": "1.0.0",
+                    "type": "Feature",
+                    "id": "item-2",
+                    "geometry": None,
+                    # Missing required 'properties' field
+                    "links": [{"rel": "self", "href": "http://example.com"}],
+                    "assets": {},
+                },
+            ],
+        }
+        fc_path.write_text(json.dumps(fc_data))
+
+        fv = FastValidator(str(fc_path), quiet=True)
+        fv.run()
+
+        msg = fv.message[0]
+
+        # For mixed valid/invalid items
+        assert msg["valid_stac"] is False
+        assert msg["total_objects"] == 2
+        assert msg["valid_objects"] == 1
+        assert msg["invalid_objects"] == 1
+        assert len(msg["errors"]) > 0
+
+        # Verify error structure
+        for error in msg["errors"]:
+            assert "error_message" in error
+            assert "affected_items" in error
+            assert "count" in error
+            assert isinstance(error["affected_items"], list)
+            assert error["count"] == len(error["affected_items"])


### PR DESCRIPTION
### Added

- Added message output for fast validator command [#292](https://github.com/stac-utils/stac-validator/pull/292)

### Removed

- Deprecation warnings for `stac-validator` installation [#292](https://github.com/stac-utils/stac-validator/pull/292)