### PR TITLE
Make the project name consistent with repository and package name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "stac_valid"
+name = "stac_validator"
 version = "4.5.0"
 description = "A package to validate STAC files"
 authors = [


### PR DESCRIPTION
This change is motivated based on downstream packaging in Nixpkgs where we check consistency of python metadata and package name.